### PR TITLE
[BE] FIX: Kong -> Chat 서버 접속 가능 코드 수정 #79

### DIFF
--- a/src/backend/chat-server/src/main/java/kickzo/stomp_chat/config/WebSocketConfig.java
+++ b/src/backend/chat-server/src/main/java/kickzo/stomp_chat/config/WebSocketConfig.java
@@ -20,7 +20,9 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         // 클라이언트가 연결할 WebSocket 엔드포인트 설정
-        registry.addEndpoint("/ws").withSockJS();
+        registry.addEndpoint("/ws")
+                .setAllowedOriginPatterns("*")
+                .withSockJS();
     }
 }
 

--- a/src/backend/chat-server/src/main/resources/static/index.html
+++ b/src/backend/chat-server/src/main/resources/static/index.html
@@ -50,7 +50,7 @@
     let roomId = '1'; // 테스트용 단일 방 ID
 
     function connect() {
-        const socket = new SockJS('/ws');
+        const socket = new SockJS('/api/chat/ws');
         stompClient = Stomp.over(socket);
         stompClient.connect({}, () => {
             console.log('Connected');


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [x] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명

### 🔗 관련 이슈

<!-- 이슈를 해결했다면 아래에 이슈번호를 숫자로 바꿔주세요. 예) closed #42
  이슈 번호를 작성하면 자동으로 이슈가 닫힙니다. -->

**해결한 이슈**: closed #79

### 📝 작업 내용

<!-- 작업 내용에 대한 설명을 적어주세요. -->
spring 프로젝트에서 외부(ex: kong)에서 접속 가능하도록 허용해줘야 정상적으로 웹소켓이 연결됩니다.

### 기존 코드:
public void registerStompEndpoints(StompEndpointRegistry registry) {
    // 클라이언트가 연결할 WebSocket 엔드포인트 설정
    registry.addEndpoint("/ws") .withSockJS();
}

### 수정된 코드:
public void registerStompEndpoints(StompEndpointRegistry registry) {
    // 클라이언트가 연결할 WebSocket 엔드포인트 설정
    registry.addEndpoint("/ws")
            .setAllowedOriginPatterns("*")
            .withSockJS();
}

.setAllowedOriginPatterns("*") 코드를 추가해서 현재는 kong gateway 이외의 외부에서도 접속을 허용하게 해놨습니다.

kong만 허용할거라면 * 대신 http://localhost:8000 으로 작성 가능!!

### 📸 스크린샷(optional)
![image](https://github.com/user-attachments/assets/a7b729a8-19a3-4c1f-90b7-35c8ac729c78)


<!-- 이해에 도움이 될만한 스크린샷을 첨부해주세요. -->
