### PR TITLE
[BE] FEAT: save connection to redis #102

### DIFF
--- a/src/backend/state-server/build.gradle
+++ b/src/backend/state-server/build.gradle
@@ -18,9 +18,9 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.kafka:spring-kafka'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'io.projectreactor:reactor-test'
 	testImplementation 'org.springframework.kafka:spring-kafka-test'

--- a/src/backend/state-server/src/main/java/com/example/state/config/RedisConfig.java
+++ b/src/backend/state-server/src/main/java/com/example/state/config/RedisConfig.java
@@ -1,0 +1,38 @@
+package com.example.state.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        LettuceConnectionFactory factory = new LettuceConnectionFactory(host, port);
+        factory.setDatabase(1);
+        return factory;
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        return template;
+    }
+
+    @Bean
+    public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory connectionFactory) {
+        return new StringRedisTemplate(connectionFactory);
+    }
+}

--- a/src/backend/state-server/src/main/java/com/example/state/service/RedisService.java
+++ b/src/backend/state-server/src/main/java/com/example/state/service/RedisService.java
@@ -1,0 +1,51 @@
+package com.example.state.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+public class RedisService {
+    private static final Logger logger = LoggerFactory.getLogger(RedisService.class);
+    private final StringRedisTemplate redisTemplate;
+
+    public RedisService(StringRedisTemplate redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    //사용자 상태 저장 (case JOIN)
+    public void saveUserState(String userId, String status, String serverPort, String timestamp) {
+        String key = "user:state:" + userId;
+
+        Map<String, String> stateData = new HashMap<>();
+        stateData.put("status", status);
+        stateData.put("serverPort", serverPort);
+        stateData.put("timestamp", timestamp);
+
+        // Redis 연결 정보 로그 출력
+        logger.info("Connecting to Redis at {}:{}", redisHost, redisPort);
+        // 저장하기 전에 로그 출력
+        logger.info("Saving user state to Redis - Key: {}, Data: {}", key, stateData);
+
+        redisTemplate.opsForHash().putAll(key, stateData);
+
+        // 저장 후 로그 출력
+        logger.info("Successfully saved user state for userId: {}", userId);
+    }
+
+    //사용자 상태 조회
+
+    //사용자 상태 삭제
+}

--- a/src/backend/state-server/src/main/java/com/example/state/service/StateManager.java
+++ b/src/backend/state-server/src/main/java/com/example/state/service/StateManager.java
@@ -1,12 +1,40 @@
 package com.example.state.service;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Service;
 
 @Service
 public class StateManager {
 
+    private final RedisService redisService;
+    private final ObjectMapper objectMapper;
+
+    public StateManager(RedisService redisService, ObjectMapper objectMapper) {
+        this.redisService = redisService;
+        this.objectMapper = objectMapper;
+    }
+
     // 메시지를 수신하고 처리하는 간단한 로직
     public void consumeMessage(String message) {
         // 메시지 처리
+        try {
+            JsonNode jsonNode = objectMapper.readTree(message);
+            String eventType = jsonNode.get("eventType").asText();
+            String userId = jsonNode.get("userId").asText();
+            String serverPort = jsonNode.get("serverPort").asText();
+            String timestamp = jsonNode.get("timestamp").asText();
+
+            System.out.println("Processing event: " + eventType + " for user: " + userId);
+
+            if ("JOIN".equals(eventType)) {
+                //online 상태 저장
+                redisService.saveUserState(userId, "online", serverPort, timestamp);
+            } else {
+                //유저 상태 제거 ("LEAVE")
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 }

--- a/src/backend/state-server/src/main/resources/application-dev.properties
+++ b/src/backend/state-server/src/main/resources/application-dev.properties
@@ -1,1 +1,6 @@
 spring.kafka.bootstrap-servers=localhost:19092
+
+spring.data.redis.database=1
+spring.data.redis.host=localhost
+spring.data.redis.port=7003
+spring.data.redis.timeout=60000

--- a/src/backend/state-server/src/main/resources/application-docker.properties
+++ b/src/backend/state-server/src/main/resources/application-docker.properties
@@ -1,1 +1,6 @@
 spring.kafka.bootstrap-servers=kafka:9092
+
+spring.data.redis.database=1
+spring.data.redis.host=redis
+spring.data.redis.port=6379
+spring.data.redis.timeout=60000

--- a/src/backend/state-server/src/main/resources/application.properties
+++ b/src/backend/state-server/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 spring.application.name=state
 
-server.port=8144
+server.port=8104
 
 spring.profiles.active=dev
 

--- a/src/backend/state-server/src/main/resources/application.properties
+++ b/src/backend/state-server/src/main/resources/application.properties
@@ -1,9 +1,10 @@
 spring.application.name=state
 
-server.port=8104
+server.port=8144
 
 spring.profiles.active=dev
 
 spring.kafka.consumer.group-id=my-group-${server.port}
 spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer
 spring.kafka.producer.value-serializer=org.apache.kafka.common.serialization.StringSerializer
+


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명

### 🔗 관련 이슈

<!-- 이슈를 해결했다면 아래에 이슈번호를 숫자로 바꿔주세요. 예) closed #42
  이슈 번호를 작성하면 자동으로 이슈가 닫힙니다. -->

**해결한 이슈**: closed #102

### 📝 작업 내용

<!-- 작업 내용에 대한 설명을 적어주세요. -->
kafka로부터 consume한 데이터를 redis로 저장하는 기능을 구현한 작업입니다.

Redis의 db1에 저장
현재 {userId, serverPort, status, ts} 저장.

### 📸 스크린샷(optional)

<!-- 이해에 도움이 될만한 스크린샷을 첨부해주세요. -->
