### PR TITLE
[BE] FEAT: 메인 서버 - 초대 기능 추가 및 API endpoint 수정

### DIFF
--- a/src/backend/main-server/main/src/main/java/com/kickzo/main/config/RedisConfig.java
+++ b/src/backend/main-server/main/src/main/java/com/kickzo/main/config/RedisConfig.java
@@ -4,11 +4,18 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
-import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
+import com.kickzo.main.dto.data.InvitationData;
 
 @Configuration
 public class RedisConfig {
@@ -21,31 +28,34 @@ public class RedisConfig {
 
 	@Bean
 	public RedisConnectionFactory redisConnectionFactory() {
-		LettuceConnectionFactory factory = new LettuceConnectionFactory(host, port);
-		factory.setDatabase(3);
-		return factory;
+		RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration(host, port);
+		configuration.setDatabase(3);
+		return new LettuceConnectionFactory(configuration);
 	}
 
+
 	@Bean
-	public RedisTemplate<String, Object> redisTemplateObject(RedisConnectionFactory connectionFactory) {
-		RedisTemplate<String, Object> template = new RedisTemplate<>();
+	public RedisTemplate<String, InvitationData> redisInvitationTemplate(RedisConnectionFactory connectionFactory) {
+		RedisTemplate<String, InvitationData> template = new RedisTemplate<>();
 		template.setConnectionFactory(connectionFactory);
+
+		// Key는 String 직렬화
 		template.setKeySerializer(new StringRedisSerializer());
-		template.setHashKeySerializer(new StringRedisSerializer());
-		template.setValueSerializer(new GenericJackson2JsonRedisSerializer()); // Object 직렬화 지원
+
+		// 커스텀 ObjectMapper 설정
+		ObjectMapper objectMapper = new ObjectMapper();
+		objectMapper.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.ANY);
+		objectMapper.activateDefaultTyping(
+			LaissezFaireSubTypeValidator.instance,
+			ObjectMapper.DefaultTyping.NON_FINAL,
+			JsonTypeInfo.As.PROPERTY
+		);
+
+		// Value는 InvitationData로 직렬화 및 역직렬화
+		Jackson2JsonRedisSerializer<InvitationData> serializer = new Jackson2JsonRedisSerializer<>(InvitationData.class);
+		template.setValueSerializer(serializer);
+
+		template.afterPropertiesSet();
 		return template;
-	}
-
-
-	@Bean
-	public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
-		RedisTemplate<String, String> template = new RedisTemplate<>();
-		template.setConnectionFactory(connectionFactory);
-		return template;
-	}
-
-	@Bean
-	public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory connectionFactory) {
-		return new StringRedisTemplate(connectionFactory);
 	}
 }

--- a/src/backend/main-server/main/src/main/java/com/kickzo/main/controller/InvitationController.java
+++ b/src/backend/main-server/main/src/main/java/com/kickzo/main/controller/InvitationController.java
@@ -5,11 +5,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.kickzo.main.dto.request.RoomInviteRequestDto;
-import com.kickzo.main.dto.response.RoomEntryResponseDto;
 import com.kickzo.main.service.InvitationService;
 import com.kickzo.main.service.RoomService;
 
@@ -25,28 +23,27 @@ public class InvitationController {
 	private final InvitationService invitationService;
 
 	@PostMapping()
-	public ResponseEntity<?> sendInvitation(
-		@RequestHeader(value = "x-user-id") Long senderId,
+	public ResponseEntity<String> sendInvitation(
+		//@RequestHeader(value = "x-user-id") Long senderId,
 		@RequestBody RoomInviteRequestDto inviteRequestDto) {
 		invitationService.saveInvitation(inviteRequestDto);
-		return ResponseEntity.ok().build();
+		return ResponseEntity.ok("Invitation sent");
 	}
 
 	@PostMapping("/accept")
-	public ResponseEntity<RoomEntryResponseDto> acceptInvitation(
-		@RequestHeader(value = "x-user-id") Long receiverId,
+	public ResponseEntity<String> acceptInvitation(
+		//@RequestHeader(value = "x-user-id") Long receiverId,
 		@RequestBody RoomInviteRequestDto inviteRequestDto) {
 		invitationService.acceptInvitation(inviteRequestDto);
-		RoomEntryResponseDto response = roomService.getRoomJoinResponse(inviteRequestDto.getRoomCode(), receiverId);
-		return ResponseEntity.ok(response);
+		roomService.getRoomJoinResponse(inviteRequestDto.getRoomCode(), inviteRequestDto.getReceiverId());
+		return ResponseEntity.ok("Invitation accepted");
 	}
 
 	@PostMapping("/reject")
-	public ResponseEntity<?> rejectInvitation(
-		@RequestHeader(value = "x-user-id") Long receiverId,
-		@RequestParam Long senderId,
-		@RequestParam Long roomId) {
-		invitationService.rejectInvitation(senderId, receiverId, roomId);
-		return ResponseEntity.ok().build();
+	public ResponseEntity<String> rejectInvitation(
+		//@RequestHeader(value = "x-user-id") Long receiverId,
+		@RequestBody RoomInviteRequestDto inviteRequestDto) {
+		invitationService.rejectInvitation(inviteRequestDto);
+		return ResponseEntity.ok("Invitation rejected");
 	}
 }

--- a/src/backend/main-server/main/src/main/java/com/kickzo/main/controller/InvitationController.java
+++ b/src/backend/main-server/main/src/main/java/com/kickzo/main/controller/InvitationController.java
@@ -26,7 +26,7 @@ public class InvitationController {
 	public ResponseEntity<String> sendInvitation(
 		//@RequestHeader(value = "x-user-id") Long senderId,
 		@RequestBody RoomInviteRequestDto inviteRequestDto) {
-		invitationService.saveInvitation(inviteRequestDto);
+		invitationService.sendInvitation(inviteRequestDto);
 		return ResponseEntity.ok("Invitation sent");
 	}
 

--- a/src/backend/main-server/main/src/main/java/com/kickzo/main/controller/InvitationController.java
+++ b/src/backend/main-server/main/src/main/java/com/kickzo/main/controller/InvitationController.java
@@ -24,26 +24,26 @@ public class InvitationController {
 
 	@PostMapping()
 	public ResponseEntity<String> sendInvitation(
-		//@RequestHeader(value = "x-user-id") Long senderId,
+		@RequestHeader(value = "x-user-id") Long senderId,
 		@RequestBody RoomInviteRequestDto inviteRequestDto) {
-		invitationService.sendInvitation(inviteRequestDto);
+		invitationService.sendInvitation(senderId, inviteRequestDto);
 		return ResponseEntity.ok("Invitation sent");
 	}
 
 	@PostMapping("/accept")
 	public ResponseEntity<String> acceptInvitation(
-		//@RequestHeader(value = "x-user-id") Long receiverId,
+		@RequestHeader(value = "x-user-id") Long receiverId,
 		@RequestBody RoomInviteRequestDto inviteRequestDto) {
-		invitationService.acceptInvitation(inviteRequestDto);
-		roomService.getRoomJoinResponse(inviteRequestDto.getRoomCode(), inviteRequestDto.getReceiverId());
+		invitationService.acceptInvitation(receiverId, inviteRequestDto);
+		roomService.getRoomJoinResponse(inviteRequestDto.getRoomCode(), receiverId);
 		return ResponseEntity.ok("Invitation accepted");
 	}
 
 	@PostMapping("/reject")
 	public ResponseEntity<String> rejectInvitation(
-		//@RequestHeader(value = "x-user-id") Long receiverId,
+		@RequestHeader(value = "x-user-id") Long receiverId,
 		@RequestBody RoomInviteRequestDto inviteRequestDto) {
-		invitationService.rejectInvitation(inviteRequestDto);
+		invitationService.rejectInvitation(receiverId, inviteRequestDto);
 		return ResponseEntity.ok("Invitation rejected");
 	}
 }

--- a/src/backend/main-server/main/src/main/java/com/kickzo/main/controller/MainPageApi.java
+++ b/src/backend/main-server/main/src/main/java/com/kickzo/main/controller/MainPageApi.java
@@ -41,7 +41,7 @@ public interface MainPageApi {
 		@ApiResponse(responseCode = "MAIN-500-999", description = ApiResponseConstants.UNEXPECTED_ERROR_MESSAGE)
 	})
 	ResponseEntity<List<RoomResponseDto>> getUserRooms(
-		@RequestHeader(value = "x-user-id", required = true) Long userId
+		@RequestHeader(value = "x-user-id") Long userId
 	);
 
 	@Operation(summary = "방 생성", description = "사용자가 새로운 방을 생성합니다.")
@@ -56,7 +56,7 @@ public interface MainPageApi {
 		@ApiResponse(responseCode = "MAIN-500-999", description = ApiResponseConstants.UNEXPECTED_ERROR_MESSAGE)
 	})
 	ResponseEntity<CreateRoomResponseDto> createRoom(
-		@RequestHeader(value = "x-user-id", required = true) Long userId,
+		@RequestHeader(value = "x-user-id") Long userId,
 		@RequestBody CreateRoomRequestDto requestDto
 	);
 }

--- a/src/backend/main-server/main/src/main/java/com/kickzo/main/controller/MainPageController.java
+++ b/src/backend/main-server/main/src/main/java/com/kickzo/main/controller/MainPageController.java
@@ -41,7 +41,7 @@ public class MainPageController implements MainPageApi {
 	@Override
 	@GetMapping("/me")
 	public ResponseEntity<List<RoomResponseDto>> getUserRooms(
-		@RequestHeader(value = "x-user-id", required = true) Long userId) {
+		@RequestHeader(value = "x-user-id") Long userId) {
 		log.info("get user rooms. userId: {}", userId);
 		return ResponseEntity.ok(mainPageService.getUserRooms(userId));
 	}
@@ -49,7 +49,7 @@ public class MainPageController implements MainPageApi {
 	@Override
 	@PostMapping("/create-room")
 	public ResponseEntity<CreateRoomResponseDto> createRoom(
-		@RequestHeader(value = "x-user-id", required = true) Long userId,
+		@RequestHeader(value = "x-user-id") Long userId,
 		@Valid @RequestBody CreateRoomRequestDto requestDto) {
 		log.info("create room for userId: {}", userId);
 		return ResponseEntity.ok(mainPageService.createRoom(userId, requestDto));

--- a/src/backend/main-server/main/src/main/java/com/kickzo/main/controller/RoomApi.java
+++ b/src/backend/main-server/main/src/main/java/com/kickzo/main/controller/RoomApi.java
@@ -5,6 +5,7 @@ import java.util.List;
 import com.kickzo.main.constants.ApiResponseConstants;
 import com.kickzo.main.dto.request.RoleChangeRequestDto;
 import com.kickzo.main.dto.request.RoomJoinRequestDto;
+import com.kickzo.main.dto.request.RoomPlaylistRequestDto;
 import com.kickzo.main.dto.request.RoomUpdateRequestDto;
 import com.kickzo.main.dto.response.RoomEntryResponseDto;
 import com.kickzo.main.dto.response.UserListDto;
@@ -76,8 +77,7 @@ public interface RoomApi {
 	})
 	ResponseEntity<String> savePlaylist(
 		@RequestHeader(value = "x-user-id", required = true) Long userId,
-		@RequestBody Long roomId,
-		@RequestBody String playlistJson
+		@RequestBody RoomPlaylistRequestDto playlistRequestDto
 	);
 
 	@Operation(summary = "role 변경", description = "특정 방에 권한 있는 사용자가 tragetId의 role을 변경합니다.")

--- a/src/backend/main-server/main/src/main/java/com/kickzo/main/controller/RoomController.java
+++ b/src/backend/main-server/main/src/main/java/com/kickzo/main/controller/RoomController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.kickzo.main.dto.request.RoleChangeRequestDto;
 import com.kickzo.main.dto.request.RoomJoinRequestDto;
+import com.kickzo.main.dto.request.RoomPlaylistRequestDto;
 import com.kickzo.main.dto.request.RoomUpdateRequestDto;
 import com.kickzo.main.dto.response.RoomEntryResponseDto;
 import com.kickzo.main.dto.response.UserListDto;
@@ -35,20 +36,13 @@ public class RoomController implements RoomApi {
 	private final PlaylistService playlistService;
 	private final RoomUserService roomUserService;
 
-	/**
-	 * 방 입장 로직 (WebSocket + STOMP)
-	 * @param userId, roomCode
-	 * @return RoomEntryResponseDto (방 정보, 유저 리스트, 역할 등)
-	 */
 	@Override
 	@PostMapping("/join")
 	public ResponseEntity<RoomEntryResponseDto> joinRoom(
 		@RequestHeader(value = "x-user-id", required = false) Long userId,
 		@RequestBody RoomJoinRequestDto roomJoinRequestDto) {
-
 		String roomCode = roomJoinRequestDto.getRoomCode();
-		log.info("UserId = {}, RoomCode = {}", userId, roomCode);
-
+		log.info("Join Room : UserId = {}, RoomCode = {}", userId, roomCode);
 		RoomEntryResponseDto response = roomService.getRoomJoinResponse(roomCode, userId);
 		return ResponseEntity.ok(response);
 	}
@@ -56,8 +50,9 @@ public class RoomController implements RoomApi {
 	@Override
 	@PostMapping("/update")
 	public ResponseEntity<?> updateRoomInfo(
-		@RequestHeader(value = "x-user-id", required = true) Long userId,
+	@RequestHeader(value = "x-user-id") Long userId,
 		@Valid @RequestBody RoomUpdateRequestDto requestDto) {
+		log.info("Room Update : UserId = {}, RoomCode = {}", userId, requestDto);
 		roomUserService.checkAccessRole(userId, requestDto.getRoomId());
 		roomService.updateRoomInfo(requestDto);
 		return ResponseEntity.ok("Room updated successfully");
@@ -66,9 +61,10 @@ public class RoomController implements RoomApi {
 	@Override
 	@PostMapping("/playlist")
 	public ResponseEntity<String> savePlaylist(
-		@RequestHeader(value = "x-user-id", required = true) Long userId,
-		@RequestBody Long roomId,
-		@RequestBody String playlistJson) {
+		@RequestHeader(value = "x-user-id") Long userId,
+		@RequestBody RoomPlaylistRequestDto playlistRequestDto) {
+		Long roomId = playlistRequestDto.getRoomId();
+		String playlistJson = playlistRequestDto.getPlaylistJson();
 		log.info("Saving playlist for room: {}, playlist: {}", roomId, playlistJson);
 		roomUserService.checkAccessRole(userId, roomId);
 		playlistService.savePlaylist(roomId, playlistJson);
@@ -78,8 +74,9 @@ public class RoomController implements RoomApi {
 	@Override
 	@PatchMapping("/change-role")
 	public ResponseEntity<String> changeUserRole(
-		@RequestHeader(value = "x-user-id", required = true) Long userId,
+		@RequestHeader(value = "x-user-id") Long userId,
 		@RequestBody RoleChangeRequestDto roleChangeRequestDto) {
+		log.info("Changing user role: {}", roleChangeRequestDto);
 		roomUserService.changeUserRole(userId, roleChangeRequestDto);
 		return ResponseEntity.ok("User role updated successfully.");
 	}

--- a/src/backend/main-server/main/src/main/java/com/kickzo/main/controller/RoomController.java
+++ b/src/backend/main-server/main/src/main/java/com/kickzo/main/controller/RoomController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.kickzo.main.dto.data.PlaylistItem;
 import com.kickzo.main.dto.request.RoleChangeRequestDto;
 import com.kickzo.main.dto.request.RoomJoinRequestDto;
 import com.kickzo.main.dto.request.RoomPlaylistRequestDto;
@@ -64,10 +65,10 @@ public class RoomController implements RoomApi {
 		@RequestHeader(value = "x-user-id") Long userId,
 		@RequestBody RoomPlaylistRequestDto playlistRequestDto) {
 		Long roomId = playlistRequestDto.getRoomId();
-		String playlistJson = playlistRequestDto.getPlaylistJson();
-		log.info("Saving playlist for room: {}, playlist: {}", roomId, playlistJson);
+		List<PlaylistItem> playlistItems = playlistRequestDto.getPlaylistJson();
+		log.info("Saving playlist for room: {}, playlist: {}", roomId, playlistItems);
 		roomUserService.checkAccessRole(userId, roomId);
-		playlistService.savePlaylist(roomId, playlistJson);
+		playlistService.savePlaylist(roomId, playlistItems);
 		return ResponseEntity.ok("Playlist saved successfully");
 	}
 

--- a/src/backend/main-server/main/src/main/java/com/kickzo/main/dto/data/InvitationData.java
+++ b/src/backend/main-server/main/src/main/java/com/kickzo/main/dto/data/InvitationData.java
@@ -1,0 +1,23 @@
+package com.kickzo.main.dto.data;
+
+import com.kickzo.main.enums.InvitationStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class InvitationData {
+	private String type;
+	private Long senderId;
+	private String senderNickname;
+	private Long receiverId;
+	private String receiverNickname;
+	private String timestamp;
+	private Long roomId;
+	private String roomCode;
+	private String isRead;
+	private InvitationStatus status;
+}

--- a/src/backend/main-server/main/src/main/java/com/kickzo/main/dto/data/InvitationData.java
+++ b/src/backend/main-server/main/src/main/java/com/kickzo/main/dto/data/InvitationData.java
@@ -1,5 +1,6 @@
 package com.kickzo.main.dto.data;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.kickzo.main.enums.InvitationStatus;
 
 import lombok.AllArgsConstructor;
@@ -15,9 +16,10 @@ public class InvitationData {
 	private String senderNickname;
 	private Long receiverId;
 	private String receiverNickname;
-	private String timestamp;
+	private Long timestamp;
 	private Long roomId;
 	private String roomCode;
-	private String isRead;
+	@JsonProperty("isRead")
+	private boolean isRead;
 	private InvitationStatus status;
 }

--- a/src/backend/main-server/main/src/main/java/com/kickzo/main/dto/data/PlaylistItem.java
+++ b/src/backend/main-server/main/src/main/java/com/kickzo/main/dto/data/PlaylistItem.java
@@ -1,4 +1,4 @@
-package com.kickzo.main.dto.event;
+package com.kickzo.main.dto.data;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/backend/main-server/main/src/main/java/com/kickzo/main/dto/event/PlaylistUpdateEvent.java
+++ b/src/backend/main-server/main/src/main/java/com/kickzo/main/dto/event/PlaylistUpdateEvent.java
@@ -2,6 +2,8 @@ package com.kickzo.main.dto.event;
 
 import java.util.List;
 
+import com.kickzo.main.dto.data.PlaylistItem;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/backend/main-server/main/src/main/java/com/kickzo/main/dto/request/RoomPlaylistRequestDto.java
+++ b/src/backend/main-server/main/src/main/java/com/kickzo/main/dto/request/RoomPlaylistRequestDto.java
@@ -1,9 +1,13 @@
 package com.kickzo.main.dto.request;
 
+import java.util.List;
+
+import com.kickzo.main.dto.data.PlaylistItem;
+
 import lombok.Data;
 
 @Data
 public class RoomPlaylistRequestDto {
 	private Long roomId;
-	private String playlistJson;
+	private List<PlaylistItem> playlistJson;
 }

--- a/src/backend/main-server/main/src/main/java/com/kickzo/main/dto/request/RoomPlaylistRequestDto.java
+++ b/src/backend/main-server/main/src/main/java/com/kickzo/main/dto/request/RoomPlaylistRequestDto.java
@@ -1,0 +1,9 @@
+package com.kickzo.main.dto.request;
+
+import lombok.Data;
+
+@Data
+public class RoomPlaylistRequestDto {
+	private Long roomId;
+	private String playlistJson;
+}

--- a/src/backend/main-server/main/src/main/java/com/kickzo/main/dto/response/RoomDetailsDto.java
+++ b/src/backend/main-server/main/src/main/java/com/kickzo/main/dto/response/RoomDetailsDto.java
@@ -2,7 +2,7 @@ package com.kickzo.main.dto.response;
 
 import java.util.List;
 
-import com.kickzo.main.dto.event.PlaylistItem;
+import com.kickzo.main.dto.data.PlaylistItem;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src/backend/main-server/main/src/main/java/com/kickzo/main/entity/Playlist.java
+++ b/src/backend/main-server/main/src/main/java/com/kickzo/main/entity/Playlist.java
@@ -1,5 +1,14 @@
 package com.kickzo.main.entity;
 
+import java.util.List;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kickzo.main.dto.data.PlaylistItem;
+import com.kickzo.main.exception.CustomErrorCode;
+import com.kickzo.main.exception.CustomException;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
@@ -25,4 +34,24 @@ public class Playlist {
 	@OneToOne
 	@JoinColumn(name = "room_id", insertable = false, updatable = false)
 	private Room room;
+
+	// JSON 문자열 -> List<PlaylistItem> 변환
+	public List<PlaylistItem> getOrderAsList() {
+		ObjectMapper objectMapper = new ObjectMapper();
+		try {
+			return objectMapper.readValue(order, new TypeReference<>() {});
+		} catch (JsonProcessingException e) {
+			throw new CustomException(CustomErrorCode.JSON_PROCESSING_ERROR);
+		}
+	}
+
+	// List<PlaylistItem> -> JSON 문자열 변환
+	public void setOrderFromList(List<PlaylistItem> playlistItems) {
+		ObjectMapper objectMapper = new ObjectMapper();
+		try {
+			this.order = objectMapper.writeValueAsString(playlistItems);
+		} catch (JsonProcessingException e) {
+			throw new CustomException(CustomErrorCode.JSON_PROCESSING_ERROR);
+		}
+	}
 }

--- a/src/backend/main-server/main/src/main/java/com/kickzo/main/enums/InvitationStatus.java
+++ b/src/backend/main-server/main/src/main/java/com/kickzo/main/enums/InvitationStatus.java
@@ -4,9 +4,4 @@ public enum InvitationStatus {
 	PENDING,
 	ACCEPTED,
 	REJECTED;
-
-	@Override
-	public String toString() {
-		return name().toLowerCase();
-	}
 }

--- a/src/backend/main-server/main/src/main/java/com/kickzo/main/enums/InvitationStatus.java
+++ b/src/backend/main-server/main/src/main/java/com/kickzo/main/enums/InvitationStatus.java
@@ -3,5 +3,5 @@ package com.kickzo.main.enums;
 public enum InvitationStatus {
 	PENDING,
 	ACCEPTED,
-	REJECTED;
+	REJECTED
 }

--- a/src/backend/main-server/main/src/main/java/com/kickzo/main/enums/InvitationStatus.java
+++ b/src/backend/main-server/main/src/main/java/com/kickzo/main/enums/InvitationStatus.java
@@ -1,0 +1,12 @@
+package com.kickzo.main.enums;
+
+public enum InvitationStatus {
+	PENDING,
+	ACCEPTED,
+	REJECTED;
+
+	@Override
+	public String toString() {
+		return name().toLowerCase();
+	}
+}

--- a/src/backend/main-server/main/src/main/java/com/kickzo/main/exception/CustomErrorCode.java
+++ b/src/backend/main-server/main/src/main/java/com/kickzo/main/exception/CustomErrorCode.java
@@ -22,6 +22,7 @@ public enum CustomErrorCode {
 	USER_NOT_FOUND("MAIN-404-002", "사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
 	ROOM_USER_NOT_FOUND("MAIN-404-003", "방-사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
 	//PLAYLIST_NOT_FOUND("MAIN-404-004", "플레이리스트를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+	INVITATION_NOT_FOUND("MAIN-404-005", "초대 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
 
 	DUPLICATE_INVITATION("MAIN-409-001", "이미 보낸 요청입니다.", HttpStatus.CONFLICT),
 	INVITATION_REJECTED("MAIN-409-002", "이전에 초대가 거절되어 다시 초대할 수 없습니다.", HttpStatus.CONFLICT),

--- a/src/backend/main-server/main/src/main/java/com/kickzo/main/exception/CustomErrorCode.java
+++ b/src/backend/main-server/main/src/main/java/com/kickzo/main/exception/CustomErrorCode.java
@@ -13,6 +13,8 @@ public enum CustomErrorCode {
 	REQUIRED_UPDATE_FIELDS_MISSING("MAIN-400-003", "적어도 하나의 변경할 값을 입력해야 합니다.", HttpStatus.BAD_REQUEST),
 	INVALID_PLAYLIST("MAIN-400-004", "Playlist roomId가 null 입니다.", HttpStatus.BAD_REQUEST),
 	INVALID_ROOM ("MAIN-400-005", "roomId와 roomCode가 불일치 합니다.", HttpStatus.BAD_REQUEST),
+	INVALID_SENDER ("MAIN-400-006", "userId와 senderId가 불일치 합니다.", HttpStatus.BAD_REQUEST),
+	INVALID_RECEIVER ("MAIN-400-007", "userId와 receiverId가 불일치 합니다.", HttpStatus.BAD_REQUEST),
 
 	INVALID_ACCESS_ROLE("MAIN-401-001", "수정 권한이 없는 유저입니다.", HttpStatus.UNAUTHORIZED),
 
@@ -23,12 +25,13 @@ public enum CustomErrorCode {
 	ROOM_USER_NOT_FOUND("MAIN-404-003", "방-사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
 	//PLAYLIST_NOT_FOUND("MAIN-404-004", "플레이리스트를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
 	INVITATION_NOT_FOUND("MAIN-404-005", "초대 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+	SENDER_NOT_FOUND("MAIN-404-006", "요청 보낸 사용자가 방에 소속되어 있지 않습니다.", HttpStatus.NOT_FOUND),
 
-	DUPLICATE_INVITATION("MAIN-409-001", "이미 보낸 요청입니다.", HttpStatus.CONFLICT),
-	INVITATION_REJECTED("MAIN-409-002", "이전에 초대가 거절되어 다시 초대할 수 없습니다.", HttpStatus.CONFLICT),
-	EXISTING_ROOM_USER("MAIN-409-003", "이미 유저가 해당 방에 소속 중입니다.", HttpStatus.CONFLICT),
+	DUPLICATE_INVITATION("MAIN-409-001", "이미 초대가 진행 중입니다.", HttpStatus.CONFLICT),
+	INVITATION_REJECTED("MAIN-409-002", "이 초대는 이미 거절되었습니다.", HttpStatus.CONFLICT),
+	EXISTING_ROOM_USER("MAIN-409-003", "유저가 해당 방에 이미 소속되어 있습니다.", HttpStatus.CONFLICT),
 
-	FAILED_CREATE_INVITATION("MAIN-422-001", "초대 요청 생성에 실패했습니다.", HttpStatus.UNPROCESSABLE_ENTITY),
+	FAILED_CREATE_INVITATION("MAIN-422-001", "초대 상태를 업데이트하는 중 오류가 발생했습니다.", HttpStatus.UNPROCESSABLE_ENTITY),
 
 	FOREIGN_KEY_VIOLATION("DB-400-001", "참조하는 데이터가 존재하지 않습니다.", HttpStatus.BAD_REQUEST),
 	DATABASE_ERROR("DB-500-001", "데이터베이스 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),

--- a/src/backend/main-server/main/src/main/java/com/kickzo/main/exception/CustomErrorCode.java
+++ b/src/backend/main-server/main/src/main/java/com/kickzo/main/exception/CustomErrorCode.java
@@ -22,6 +22,10 @@ public enum CustomErrorCode {
 	ROOM_USER_NOT_FOUND("MAIN-404-003", "방-사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
 	//PLAYLIST_NOT_FOUND("MAIN-404-004", "플레이리스트를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
 
+	DUPLICATE_INVITATION("MAIN-409-001", "이미 보낸 요청입니다.", HttpStatus.CONFLICT),
+
+	FAILED_CREATE_INVITATION("MAIN-422-001", "초대 요청 생성에 실패했습니다.", HttpStatus.UNPROCESSABLE_ENTITY),
+
 	FOREIGN_KEY_VIOLATION("DB-400-001", "참조하는 데이터가 존재하지 않습니다.", HttpStatus.BAD_REQUEST),
 	DATABASE_ERROR("DB-500-001", "데이터베이스 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
 
@@ -32,6 +36,7 @@ public enum CustomErrorCode {
 
 	JSON_PROCESSING_ERROR("JSON-500-001", "JSON 직렬화 중 오류가 발생하였습니다.", HttpStatus.BAD_REQUEST),
 
+	FAILED_INVITE_STATUS_UPDATE("MAIN-500-001", "초대 상태 업데이트에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
 	UNEXPECTED_ERROR("MAIN-500-999", "예상치 못한 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
 
 	private final String code;

--- a/src/backend/main-server/main/src/main/java/com/kickzo/main/exception/CustomErrorCode.java
+++ b/src/backend/main-server/main/src/main/java/com/kickzo/main/exception/CustomErrorCode.java
@@ -12,6 +12,7 @@ public enum CustomErrorCode {
 	INVALID_ROOM_CODE("MAIN-400-002", "유효하지 않은 방 코드입니다.", HttpStatus.BAD_REQUEST),
 	REQUIRED_UPDATE_FIELDS_MISSING("MAIN-400-003", "적어도 하나의 변경할 값을 입력해야 합니다.", HttpStatus.BAD_REQUEST),
 	INVALID_PLAYLIST("MAIN-400-004", "Playlist roomId가 null 입니다.", HttpStatus.BAD_REQUEST),
+	INVALID_ROOM ("MAIN-400-005", "roomId와 roomCode가 불일치 합니다.", HttpStatus.BAD_REQUEST),
 
 	INVALID_ACCESS_ROLE("MAIN-401-001", "수정 권한이 없는 유저입니다.", HttpStatus.UNAUTHORIZED),
 
@@ -23,6 +24,8 @@ public enum CustomErrorCode {
 	//PLAYLIST_NOT_FOUND("MAIN-404-004", "플레이리스트를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
 
 	DUPLICATE_INVITATION("MAIN-409-001", "이미 보낸 요청입니다.", HttpStatus.CONFLICT),
+	INVITATION_REJECTED("MAIN-409-002", "이전에 초대가 거절되어 다시 초대할 수 없습니다.", HttpStatus.CONFLICT),
+	EXISTING_ROOM_USER("MAIN-409-003", "이미 유저가 해당 방에 소속 중입니다.", HttpStatus.CONFLICT),
 
 	FAILED_CREATE_INVITATION("MAIN-422-001", "초대 요청 생성에 실패했습니다.", HttpStatus.UNPROCESSABLE_ENTITY),
 

--- a/src/backend/main-server/main/src/main/java/com/kickzo/main/exception/CustomErrorCode.java
+++ b/src/backend/main-server/main/src/main/java/com/kickzo/main/exception/CustomErrorCode.java
@@ -30,6 +30,7 @@ public enum CustomErrorCode {
 	DUPLICATE_INVITATION("MAIN-409-001", "이미 초대가 진행 중입니다.", HttpStatus.CONFLICT),
 	INVITATION_REJECTED("MAIN-409-002", "이 초대는 이미 거절되었습니다.", HttpStatus.CONFLICT),
 	EXISTING_ROOM_USER("MAIN-409-003", "유저가 해당 방에 이미 소속되어 있습니다.", HttpStatus.CONFLICT),
+	ALREADY_PROCESSED("MAIN-409-004", "이미 처리된 요청입니다.", HttpStatus.CONFLICT),
 
 	FAILED_CREATE_INVITATION("MAIN-422-001", "초대 상태를 업데이트하는 중 오류가 발생했습니다.", HttpStatus.UNPROCESSABLE_ENTITY),
 

--- a/src/backend/main-server/main/src/main/java/com/kickzo/main/repository/RoomRepository.java
+++ b/src/backend/main-server/main/src/main/java/com/kickzo/main/repository/RoomRepository.java
@@ -27,5 +27,8 @@ public interface RoomRepository extends JpaRepository<Room, Long> {
 	Long findRoomIdByRoomCode(@Param("roomCode") String roomCode);
 
 	List<Room> findAllByCreator(String creatorNickname);
+
+	@Query(value = "SELECT EXISTS (SELECT 1 FROM room r WHERE r.id = :roomId AND r.code = :roomCode)", nativeQuery = true)
+	Integer existsByRoomIdAndRoomCode(@Param("roomId") Long roomId, @Param("roomCode") String roomCode);
 }
 

--- a/src/backend/main-server/main/src/main/java/com/kickzo/main/repository/RoomUserRepository.java
+++ b/src/backend/main-server/main/src/main/java/com/kickzo/main/repository/RoomUserRepository.java
@@ -31,4 +31,6 @@ public interface RoomUserRepository extends JpaRepository<RoomUser, RoomUserId> 
 		+ "WHERE ru.room_id = :roomId AND ru.user_id = :userId", nativeQuery = true)
 	Integer findRoleByUserIdAndRoomId(@Param("roomId") Long roomId, @Param("userId") Long userId);
 
+	@Query(value = "SELECT EXISTS (SELECT 1 FROM room_user ru WHERE ru.room_id = :roomId AND ru.user_id = :userId)", nativeQuery = true)
+	Integer existsByUserIdAndRoomId(@Param("roomId") Long roomId, @Param("userId") Long userId);
 }

--- a/src/backend/main-server/main/src/main/java/com/kickzo/main/repository/UserRepository.java
+++ b/src/backend/main-server/main/src/main/java/com/kickzo/main/repository/UserRepository.java
@@ -30,13 +30,21 @@ public class UserRepository {
 		String sql = "SELECT u.profile_image_url FROM user u WHERE u.nickname = :nickname";
 		MapSqlParameterSource params = new MapSqlParameterSource()
 			.addValue("nickname", nickname);
-		return jdbcTemplate.queryForObject(sql, params, String.class);
+		try {
+			return jdbcTemplate.queryForObject(sql, params, String.class);
+		} catch (EmptyResultDataAccessException e) {
+			return null;
+		}
 	}
 
 	public String findProfileImageUrlById(Long userId) {
 		String sql = "SELECT u.profile_image_url FROM user u WHERE u.id = :userId";
 		MapSqlParameterSource params = new MapSqlParameterSource()
 			.addValue("userId", userId);
-		return jdbcTemplate.queryForObject(sql, params, String.class);
+		try {
+			return jdbcTemplate.queryForObject(sql, params, String.class);
+		} catch (EmptyResultDataAccessException e) {
+			return null;
+		}
 	}
 }

--- a/src/backend/main-server/main/src/main/java/com/kickzo/main/service/InvitationService.java
+++ b/src/backend/main-server/main/src/main/java/com/kickzo/main/service/InvitationService.java
@@ -3,6 +3,7 @@ package com.kickzo.main.service;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.LinkedHashMap;
 import java.util.Optional;
 
 import org.springframework.data.redis.core.RedisTemplate;
@@ -27,12 +28,11 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class InvitationService {
 
-	private final RedisTemplate<String, Object> redisTemplate;
+	private final RedisTemplate<String, InvitationData> redisTemplate;
 	private final UserRepository userRepository;
 	private final KafkaProducerService kafkaProducerService;
 
 	private static final int TTL_EXPIRE_DAY = 7;
-	private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 	private final ObjectMapper objectMapper = new ObjectMapper();
 	private final RoomUserRepository roomUserRepository;
 	private final RoomRepository roomRepository;
@@ -43,16 +43,19 @@ public class InvitationService {
 		// 이미 방에 소속된 유저인 경우 오류 보내기
 		validateExistingRoomUser(inviteRequestDto);
 		String key = generateKey(inviteRequestDto);
-
 		validateExistingInvitation(key);
-
 		// 새 초대 데이터 생성 및 저장
-		String invitationData = createInvitationData(inviteRequestDto);
+		InvitationData invitationData = createInvitationData(inviteRequestDto);
 		redisTemplate.opsForValue().set(key, invitationData);
 		redisTemplate.expire(key, Duration.ofDays(TTL_EXPIRE_DAY));
 
-		kafkaProducerService.sendRoomInvitation(invitationData);
+		try {
+			kafkaProducerService.sendRoomInvitation(objectMapper.writeValueAsString(invitationData));
+		} catch (JsonProcessingException e) {
+			throw new CustomException(CustomErrorCode.JSON_PROCESSING_ERROR);
+		}
 		log.info("Invitation saved and sent to Kafka: {}", invitationData);
+
 	}
 
 	public void acceptInvitation(RoomInviteRequestDto inviteRequestDto) {
@@ -66,8 +69,7 @@ public class InvitationService {
 	private void checkRoomIdAndRoomCode(RoomInviteRequestDto inviteRequestDto) {
 		Long roomId = inviteRequestDto.getRoomId();
 		String roomCode = inviteRequestDto.getRoomCode();
-		Integer result = roomRepository.existsByRoomIdAndRoomCode(roomId, roomCode);
-		if (result == 0) {
+		if (roomRepository.existsByRoomIdAndRoomCode(roomId, roomCode) == 0) {
 			throw new CustomException(CustomErrorCode.INVALID_ROOM);
 		}
 	}
@@ -75,9 +77,7 @@ public class InvitationService {
 	private void validateExistingRoomUser(RoomInviteRequestDto inviteRequestDto) {
 		Long roomId = inviteRequestDto.getRoomId();
 		Long receiverId = inviteRequestDto.getReceiverId();
-		Integer result = roomUserRepository.existsByUserIdAndRoomId(roomId, receiverId);
-
-		if (result == 1) {
+		if (roomUserRepository.existsByUserIdAndRoomId(roomId, receiverId) == 1) {
 			throw new CustomException(CustomErrorCode.EXISTING_ROOM_USER);
 		}
 	}
@@ -93,57 +93,42 @@ public class InvitationService {
 	}
 
 	private Optional<InvitationData> getInvitationDataFromRedis(String key) {
-		String existingData = (String)redisTemplate.opsForValue().get(key);
-		if (existingData != null) {
-			try {
-				InvitationData invitationData = objectMapper.readValue(existingData, InvitationData.class);
-				log.info("Get invitationData: {}", invitationData);
-				return Optional.of(invitationData);
-			} catch (JsonProcessingException e) {
-				throw new CustomException(CustomErrorCode.JSON_PROCESSING_ERROR);
-			}
-		}
-		return Optional.empty();
+		// 바로 InvitationData로 반환
+		InvitationData invitationData = redisTemplate.opsForValue().get(key);
+		return Optional.ofNullable(invitationData);
 	}
 
-	private String createInvitationData(RoomInviteRequestDto inviteRequestDto) {
-		try {
-			InvitationData invitationData = new InvitationData(
-				"room_request",
-				inviteRequestDto.getSenderId(),
-				userRepository.findNicknameById(inviteRequestDto.getSenderId()),
-				inviteRequestDto.getReceiverId(),
-				userRepository.findNicknameById(inviteRequestDto.getReceiverId()),
-				LocalDateTime.now().format(DATE_TIME_FORMATTER),
-				inviteRequestDto.getRoomId(),
-				inviteRequestDto.getRoomCode(),
-				"false",
-				InvitationStatus.PENDING
-			);
-			return objectMapper.writeValueAsString(invitationData);
-		} catch (Exception e) {
-			log.error("Failed to create invitation data: {}", e.getMessage(), e);
-			throw new CustomException(CustomErrorCode.FAILED_CREATE_INVITATION);
-		}
+	private InvitationData createInvitationData(RoomInviteRequestDto inviteRequestDto) {
+		return new InvitationData(
+			"room_request",
+			inviteRequestDto.getSenderId(),
+			userRepository.findNicknameById(inviteRequestDto.getSenderId()),
+			inviteRequestDto.getReceiverId(),
+			userRepository.findNicknameById(inviteRequestDto.getReceiverId()),
+			System.currentTimeMillis(),
+			inviteRequestDto.getRoomId(),
+			inviteRequestDto.getRoomCode(),
+			false,
+			InvitationStatus.PENDING
+		);
 	}
+
 
 	private void updateInvitationStatus(RoomInviteRequestDto inviteRequestDto, InvitationStatus newStatus) {
 		checkRoomIdAndRoomCode(inviteRequestDto);
 
 		String key = generateKey(inviteRequestDto);
 		try {
-			String jsonData = (String) redisTemplate.opsForValue().get(key);
-			if (jsonData != null) {
-				InvitationData invitationData = objectMapper.readValue(jsonData, InvitationData.class);
+			InvitationData invitationData = redisTemplate.opsForValue().get(key);
+			if (invitationData != null) {
 				invitationData.setStatus(newStatus);  // 상태 업데이트
-
-				String updatedJsonData = objectMapper.writeValueAsString(invitationData);
-				redisTemplate.opsForValue().set(key, updatedJsonData);
+				redisTemplate.opsForValue().set(key, invitationData);
 				redisTemplate.expire(key, Duration.ofDays(TTL_EXPIRE_DAY));
 
-				log.info("Invitation status updated to {}: {}", newStatus, updatedJsonData);
+				log.info("Invitation status updated to {}: {}", newStatus, invitationData);
 			} else {
 				log.warn("Invitation not found for key: {}", key);
+				throw new CustomException(CustomErrorCode.INVITATION_NOT_FOUND);
 			}
 		} catch (Exception e) {
 			log.error("Failed to update invitation status: {}", e.getMessage(), e);

--- a/src/backend/main-server/main/src/main/java/com/kickzo/main/service/InvitationService.java
+++ b/src/backend/main-server/main/src/main/java/com/kickzo/main/service/InvitationService.java
@@ -15,6 +15,8 @@ import com.kickzo.main.dto.request.RoomInviteRequestDto;
 import com.kickzo.main.enums.InvitationStatus;
 import com.kickzo.main.exception.CustomErrorCode;
 import com.kickzo.main.exception.CustomException;
+import com.kickzo.main.repository.RoomRepository;
+import com.kickzo.main.repository.RoomUserRepository;
 import com.kickzo.main.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -32,8 +34,14 @@ public class InvitationService {
 	private static final int TTL_EXPIRE_DAY = 7;
 	private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 	private final ObjectMapper objectMapper = new ObjectMapper();
+	private final RoomUserRepository roomUserRepository;
+	private final RoomRepository roomRepository;
 
-	public void saveInvitation(RoomInviteRequestDto inviteRequestDto) {
+	public void sendInvitation(RoomInviteRequestDto inviteRequestDto) {
+		// roomId와 roomCode 일치하는 확인
+		checkRoomIdAndRoomCode(inviteRequestDto);
+		// 이미 방에 소속된 유저인 경우 오류 보내기
+		validateExistingRoomUser(inviteRequestDto);
 		String key = generateKey(inviteRequestDto);
 
 		validateExistingInvitation(key);
@@ -55,11 +63,31 @@ public class InvitationService {
 		updateInvitationStatus(inviteRequestDto, InvitationStatus.REJECTED);
 	}
 
+	private void checkRoomIdAndRoomCode(RoomInviteRequestDto inviteRequestDto) {
+		Long roomId = inviteRequestDto.getRoomId();
+		String roomCode = inviteRequestDto.getRoomCode();
+		Integer result = roomRepository.existsByRoomIdAndRoomCode(roomId, roomCode);
+		if (result == 0) {
+			throw new CustomException(CustomErrorCode.INVALID_ROOM);
+		}
+	}
+
+	private void validateExistingRoomUser(RoomInviteRequestDto inviteRequestDto) {
+		Long roomId = inviteRequestDto.getRoomId();
+		Long receiverId = inviteRequestDto.getReceiverId();
+		Integer result = roomUserRepository.existsByUserIdAndRoomId(roomId, receiverId);
+
+		if (result == 1) {
+			throw new CustomException(CustomErrorCode.EXISTING_ROOM_USER);
+		}
+	}
+
 	private void validateExistingInvitation(String key) {
 		Optional<InvitationData> existingInvitation = getInvitationDataFromRedis(key);
 		existingInvitation.ifPresent(invitation -> {
-			if (invitation.getStatus() == InvitationStatus.PENDING || invitation.getStatus() == InvitationStatus.ACCEPTED) {
-				throw new CustomException(CustomErrorCode.DUPLICATE_INVITATION);
+			switch (invitation.getStatus()) {
+				case PENDING -> throw new CustomException(CustomErrorCode.DUPLICATE_INVITATION);
+				case REJECTED -> throw new CustomException(CustomErrorCode.INVITATION_REJECTED);
 			}
 		});
 	}
@@ -100,6 +128,8 @@ public class InvitationService {
 	}
 
 	private void updateInvitationStatus(RoomInviteRequestDto inviteRequestDto, InvitationStatus newStatus) {
+		checkRoomIdAndRoomCode(inviteRequestDto);
+
 		String key = generateKey(inviteRequestDto);
 		try {
 			String jsonData = (String) redisTemplate.opsForValue().get(key);

--- a/src/backend/main-server/main/src/main/java/com/kickzo/main/service/InvitationService.java
+++ b/src/backend/main-server/main/src/main/java/com/kickzo/main/service/InvitationService.java
@@ -3,69 +3,129 @@ package com.kickzo.main.service;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Optional;
 
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kickzo.main.dto.data.InvitationData;
 import com.kickzo.main.dto.request.RoomInviteRequestDto;
+import com.kickzo.main.enums.InvitationStatus;
+import com.kickzo.main.exception.CustomErrorCode;
+import com.kickzo.main.exception.CustomException;
 import com.kickzo.main.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class InvitationService {
 
 	private final RedisTemplate<String, Object> redisTemplate;
 	private final UserRepository userRepository;
+	private final KafkaProducerService kafkaProducerService;
 
 	private static final int TTL_EXPIRE_DAY = 7;
+	private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+	private final ObjectMapper objectMapper = new ObjectMapper();
 
-	// 1. 초대 저장
 	public void saveInvitation(RoomInviteRequestDto inviteRequestDto) {
-		Long senderId = inviteRequestDto.getSenderId();
-		Long receiverId = inviteRequestDto.getReceiverId();
-		Long roomId = inviteRequestDto.getRoomId();
+		String key = generateKey(inviteRequestDto);
 
-		String key = generateKey(senderId, receiverId, roomId);
+		validateExistingInvitation(key);
 
-		String SenderNickname = userRepository.findNicknameById(senderId);
-		String ReceiverNickname = userRepository.findNicknameById(receiverId);
-		String roomCode = inviteRequestDto.getRoomCode();
-
-		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-		String formattedDate = LocalDateTime.now().format(formatter);
-
-		redisTemplate.opsForHash().put(key, "type", "room_request");
-		redisTemplate.opsForHash().put(key, "senderId", senderId);
-		redisTemplate.opsForHash().put(key, "senderNickname", SenderNickname);
-		redisTemplate.opsForHash().put(key, "receiverId", receiverId);
-		redisTemplate.opsForHash().put(key, "receiverNickname", ReceiverNickname);
-		redisTemplate.opsForHash().put(key, "timestamp", formattedDate);
-		redisTemplate.opsForHash().put(key, "roomId", roomId);
-		redisTemplate.opsForHash().put(key, "roomCode", roomCode);
-		redisTemplate.opsForHash().put(key, "isRead", "false");
-
-		// TTL 설정 (7일)
+		// 새 초대 데이터 생성 및 저장
+		String invitationData = createInvitationData(inviteRequestDto);
+		redisTemplate.opsForValue().set(key, invitationData);
 		redisTemplate.expire(key, Duration.ofDays(TTL_EXPIRE_DAY));
+
+		kafkaProducerService.sendRoomInvitation(invitationData);
+		log.info("Invitation saved and sent to Kafka: {}", invitationData);
 	}
 
-	// 2. 초대 수락
 	public void acceptInvitation(RoomInviteRequestDto inviteRequestDto) {
-		String key = generateKey(inviteRequestDto.getSenderId(), inviteRequestDto.getReceiverId(), inviteRequestDto.getRoomId());
-		if (Boolean.FALSE.toString().equals(redisTemplate.opsForHash().get(key, "isRead"))) {
-			redisTemplate.opsForHash().put(key, "isRead", "true");
+		updateInvitationStatus(inviteRequestDto, InvitationStatus.ACCEPTED);
+	}
+
+	public void rejectInvitation(RoomInviteRequestDto inviteRequestDto) {
+		updateInvitationStatus(inviteRequestDto, InvitationStatus.REJECTED);
+	}
+
+	private void validateExistingInvitation(String key) {
+		Optional<InvitationData> existingInvitation = getInvitationDataFromRedis(key);
+		existingInvitation.ifPresent(invitation -> {
+			if (invitation.getStatus() == InvitationStatus.PENDING || invitation.getStatus() == InvitationStatus.ACCEPTED) {
+				throw new CustomException(CustomErrorCode.DUPLICATE_INVITATION);
+			}
+		});
+	}
+
+	private Optional<InvitationData> getInvitationDataFromRedis(String key) {
+		String existingData = (String)redisTemplate.opsForValue().get(key);
+		if (existingData != null) {
+			try {
+				InvitationData invitationData = objectMapper.readValue(existingData, InvitationData.class);
+				log.info("Get invitationData: {}", invitationData);
+				return Optional.of(invitationData);
+			} catch (JsonProcessingException e) {
+				throw new CustomException(CustomErrorCode.JSON_PROCESSING_ERROR);
+			}
 		}
-		redisTemplate.delete(key);
+		return Optional.empty();
 	}
 
-	// 3. 초대 거절
-	public void rejectInvitation(Long senderId, Long receiverId, Long roomId) {
-		String key = generateKey(senderId, receiverId, roomId);
-		redisTemplate.delete(key);
+	private String createInvitationData(RoomInviteRequestDto inviteRequestDto) {
+		try {
+			InvitationData invitationData = new InvitationData(
+				"room_request",
+				inviteRequestDto.getSenderId(),
+				userRepository.findNicknameById(inviteRequestDto.getSenderId()),
+				inviteRequestDto.getReceiverId(),
+				userRepository.findNicknameById(inviteRequestDto.getReceiverId()),
+				LocalDateTime.now().format(DATE_TIME_FORMATTER),
+				inviteRequestDto.getRoomId(),
+				inviteRequestDto.getRoomCode(),
+				"false",
+				InvitationStatus.PENDING
+			);
+			return objectMapper.writeValueAsString(invitationData);
+		} catch (Exception e) {
+			log.error("Failed to create invitation data: {}", e.getMessage(), e);
+			throw new CustomException(CustomErrorCode.FAILED_CREATE_INVITATION);
+		}
 	}
 
-	private String generateKey(Long senderId, Long receiverId, Long roomId) {
-		return String.format("invitation:%s:%d:%d:%d", "room_request", senderId, receiverId, roomId);
+	private void updateInvitationStatus(RoomInviteRequestDto inviteRequestDto, InvitationStatus newStatus) {
+		String key = generateKey(inviteRequestDto);
+		try {
+			String jsonData = (String) redisTemplate.opsForValue().get(key);
+			if (jsonData != null) {
+				InvitationData invitationData = objectMapper.readValue(jsonData, InvitationData.class);
+				invitationData.setStatus(newStatus);  // 상태 업데이트
+
+				String updatedJsonData = objectMapper.writeValueAsString(invitationData);
+				redisTemplate.opsForValue().set(key, updatedJsonData);
+				redisTemplate.expire(key, Duration.ofDays(TTL_EXPIRE_DAY));
+
+				log.info("Invitation status updated to {}: {}", newStatus, updatedJsonData);
+			} else {
+				log.warn("Invitation not found for key: {}", key);
+			}
+		} catch (Exception e) {
+			log.error("Failed to update invitation status: {}", e.getMessage(), e);
+			throw new CustomException(CustomErrorCode.FAILED_INVITE_STATUS_UPDATE);
+		}
+	}
+
+	private String generateKey(RoomInviteRequestDto inviteRequestDto) {
+		return String.format("room_request:%d:%d:%d",
+			inviteRequestDto.getSenderId(),
+			inviteRequestDto.getReceiverId(),
+			inviteRequestDto.getRoomId()
+		);
 	}
 }

--- a/src/backend/main-server/main/src/main/java/com/kickzo/main/service/InvitationService.java
+++ b/src/backend/main-server/main/src/main/java/com/kickzo/main/service/InvitationService.java
@@ -1,9 +1,6 @@
 package com.kickzo.main.service;
 
 import java.time.Duration;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.LinkedHashMap;
 import java.util.Optional;
 
 import org.springframework.data.redis.core.RedisTemplate;
@@ -37,17 +34,19 @@ public class InvitationService {
 	private final RoomUserRepository roomUserRepository;
 	private final RoomRepository roomRepository;
 
-	public void sendInvitation(RoomInviteRequestDto inviteRequestDto) {
+	public void sendInvitation(Long senderId, RoomInviteRequestDto inviteRequestDto) {
+		ensureSenderIdMatch(senderId, inviteRequestDto);
 		// roomId와 roomCode 일치하는 확인
 		checkRoomIdAndRoomCode(inviteRequestDto);
 		// 이미 방에 소속된 유저인 경우 오류 보내기
 		validateExistingRoomUser(inviteRequestDto);
+
 		String key = generateKey(inviteRequestDto);
 		validateExistingInvitation(key);
+
 		// 새 초대 데이터 생성 및 저장
 		InvitationData invitationData = createInvitationData(inviteRequestDto);
-		redisTemplate.opsForValue().set(key, invitationData);
-		redisTemplate.expire(key, Duration.ofDays(TTL_EXPIRE_DAY));
+		saveInvitationData(key, invitationData);
 
 		try {
 			kafkaProducerService.sendRoomInvitation(objectMapper.writeValueAsString(invitationData));
@@ -55,15 +54,31 @@ public class InvitationService {
 			throw new CustomException(CustomErrorCode.JSON_PROCESSING_ERROR);
 		}
 		log.info("Invitation saved and sent to Kafka: {}", invitationData);
-
 	}
 
-	public void acceptInvitation(RoomInviteRequestDto inviteRequestDto) {
-		updateInvitationStatus(inviteRequestDto, InvitationStatus.ACCEPTED);
+	public void acceptInvitation(Long receiverId, RoomInviteRequestDto inviteRequestDto) {
+		handleInvitation(receiverId, inviteRequestDto, InvitationStatus.ACCEPTED);
 	}
 
-	public void rejectInvitation(RoomInviteRequestDto inviteRequestDto) {
-		updateInvitationStatus(inviteRequestDto, InvitationStatus.REJECTED);
+	public void rejectInvitation(Long receiverId, RoomInviteRequestDto inviteRequestDto) {
+		handleInvitation(receiverId, inviteRequestDto, InvitationStatus.REJECTED);
+	}
+
+	private void handleInvitation(Long receiverId, RoomInviteRequestDto inviteRequestDto, InvitationStatus status) {
+		ensureReceiverIdMatch(receiverId, inviteRequestDto);
+		updateInvitationStatus(inviteRequestDto, status);
+	}
+
+	private void ensureSenderIdMatch(Long senderId, RoomInviteRequestDto inviteRequestDto) {
+		if (!senderId.equals(inviteRequestDto.getSenderId())) {
+			throw new CustomException(CustomErrorCode.INVALID_SENDER);
+		}
+	}
+
+	private void ensureReceiverIdMatch(Long receiverId, RoomInviteRequestDto inviteRequestDto) {
+		if (!receiverId.equals(inviteRequestDto.getReceiverId())) {
+			throw new CustomException(CustomErrorCode.INVALID_RECEIVER);
+		}
 	}
 
 	private void checkRoomIdAndRoomCode(RoomInviteRequestDto inviteRequestDto) {
@@ -76,7 +91,13 @@ public class InvitationService {
 
 	private void validateExistingRoomUser(RoomInviteRequestDto inviteRequestDto) {
 		Long roomId = inviteRequestDto.getRoomId();
+		Long senderId = inviteRequestDto.getSenderId();
 		Long receiverId = inviteRequestDto.getReceiverId();
+		// 초대 보낸 유저가 해당 방에 있어야 함
+		if (roomUserRepository.existsByUserIdAndRoomId(roomId, senderId) == 0) {
+			throw new CustomException(CustomErrorCode.SENDER_NOT_FOUND);
+		}
+		// 초대 받은 유저가 해당 방에 없어야 함
 		if (roomUserRepository.existsByUserIdAndRoomId(roomId, receiverId) == 1) {
 			throw new CustomException(CustomErrorCode.EXISTING_ROOM_USER);
 		}
@@ -113,27 +134,28 @@ public class InvitationService {
 		);
 	}
 
-
 	private void updateInvitationStatus(RoomInviteRequestDto inviteRequestDto, InvitationStatus newStatus) {
 		checkRoomIdAndRoomCode(inviteRequestDto);
 
 		String key = generateKey(inviteRequestDto);
 		try {
 			InvitationData invitationData = redisTemplate.opsForValue().get(key);
-			if (invitationData != null) {
-				invitationData.setStatus(newStatus);  // 상태 업데이트
-				redisTemplate.opsForValue().set(key, invitationData);
-				redisTemplate.expire(key, Duration.ofDays(TTL_EXPIRE_DAY));
-
-				log.info("Invitation status updated to {}: {}", newStatus, invitationData);
-			} else {
+			if (invitationData == null) {
 				log.warn("Invitation not found for key: {}", key);
 				throw new CustomException(CustomErrorCode.INVITATION_NOT_FOUND);
 			}
+			invitationData.setStatus(newStatus);
+			saveInvitationData(key, invitationData);
+			log.info("Invitation status updated to {}: {}", newStatus, invitationData);
 		} catch (Exception e) {
 			log.error("Failed to update invitation status: {}", e.getMessage(), e);
 			throw new CustomException(CustomErrorCode.FAILED_INVITE_STATUS_UPDATE);
 		}
+	}
+
+	private void saveInvitationData(String key, InvitationData invitationData) {
+		redisTemplate.opsForValue().set(key, invitationData);
+		redisTemplate.expire(key, Duration.ofDays(TTL_EXPIRE_DAY));
 	}
 
 	private String generateKey(RoomInviteRequestDto inviteRequestDto) {

--- a/src/backend/main-server/main/src/main/java/com/kickzo/main/service/InvitationService.java
+++ b/src/backend/main-server/main/src/main/java/com/kickzo/main/service/InvitationService.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -28,12 +29,15 @@ public class InvitationService {
 	private final RedisTemplate<String, InvitationData> redisTemplate;
 	private final UserRepository userRepository;
 	private final KafkaProducerService kafkaProducerService;
-
-	private static final int TTL_EXPIRE_DAY = 7;
 	private final ObjectMapper objectMapper = new ObjectMapper();
 	private final RoomUserRepository roomUserRepository;
 	private final RoomRepository roomRepository;
 
+	private static final int TTL_EXPIRE_DAY = 7;
+	private static final int NOT_EXISTS = 0;
+	private static final int EXISTS = 1;
+
+	@Transactional
 	public void sendInvitation(Long senderId, RoomInviteRequestDto inviteRequestDto) {
 		ensureSenderIdMatch(senderId, inviteRequestDto);
 		// roomId와 roomCode 일치하는 확인
@@ -48,6 +52,10 @@ public class InvitationService {
 		InvitationData invitationData = createInvitationData(inviteRequestDto);
 		saveInvitationData(key, invitationData);
 
+		sendInvitationToKafka(invitationData);
+	}
+
+	public void sendInvitationToKafka(InvitationData invitationData) {
 		try {
 			kafkaProducerService.sendRoomInvitation(objectMapper.writeValueAsString(invitationData));
 		} catch (JsonProcessingException e) {
@@ -56,10 +64,12 @@ public class InvitationService {
 		log.info("Invitation saved and sent to Kafka: {}", invitationData);
 	}
 
+	@Transactional
 	public void acceptInvitation(Long receiverId, RoomInviteRequestDto inviteRequestDto) {
 		handleInvitation(receiverId, inviteRequestDto, InvitationStatus.ACCEPTED);
 	}
 
+	@Transactional
 	public void rejectInvitation(Long receiverId, RoomInviteRequestDto inviteRequestDto) {
 		handleInvitation(receiverId, inviteRequestDto, InvitationStatus.REJECTED);
 	}
@@ -84,7 +94,7 @@ public class InvitationService {
 	private void checkRoomIdAndRoomCode(RoomInviteRequestDto inviteRequestDto) {
 		Long roomId = inviteRequestDto.getRoomId();
 		String roomCode = inviteRequestDto.getRoomCode();
-		if (roomRepository.existsByRoomIdAndRoomCode(roomId, roomCode) == 0) {
+		if (roomRepository.existsByRoomIdAndRoomCode(roomId, roomCode) == NOT_EXISTS) {
 			throw new CustomException(CustomErrorCode.INVALID_ROOM);
 		}
 	}
@@ -94,21 +104,21 @@ public class InvitationService {
 		Long senderId = inviteRequestDto.getSenderId();
 		Long receiverId = inviteRequestDto.getReceiverId();
 		// 초대 보낸 유저가 해당 방에 있어야 함
-		if (roomUserRepository.existsByUserIdAndRoomId(roomId, senderId) == 0) {
+		if (roomUserRepository.existsByUserIdAndRoomId(roomId, senderId) == NOT_EXISTS) {
 			throw new CustomException(CustomErrorCode.SENDER_NOT_FOUND);
 		}
 		// 초대 받은 유저가 해당 방에 없어야 함
-		if (roomUserRepository.existsByUserIdAndRoomId(roomId, receiverId) == 1) {
+		if (roomUserRepository.existsByUserIdAndRoomId(roomId, receiverId) == EXISTS) {
 			throw new CustomException(CustomErrorCode.EXISTING_ROOM_USER);
 		}
 	}
 
 	private void validateExistingInvitation(String key) {
-		Optional<InvitationData> existingInvitation = getInvitationDataFromRedis(key);
-		existingInvitation.ifPresent(invitation -> {
-			switch (invitation.getStatus()) {
-				case PENDING -> throw new CustomException(CustomErrorCode.DUPLICATE_INVITATION);
-				case REJECTED -> throw new CustomException(CustomErrorCode.INVITATION_REJECTED);
+		getInvitationDataFromRedis(key).ifPresent(invitation -> {
+			if (invitation.getStatus() == InvitationStatus.PENDING) {
+				throw new CustomException(CustomErrorCode.DUPLICATE_INVITATION);
+			} else if (invitation.getStatus() == InvitationStatus.REJECTED) {
+				throw new CustomException(CustomErrorCode.INVITATION_REJECTED);
 			}
 		});
 	}
@@ -143,6 +153,9 @@ public class InvitationService {
 			if (invitationData == null) {
 				log.warn("Invitation not found for key: {}", key);
 				throw new CustomException(CustomErrorCode.INVITATION_NOT_FOUND);
+			}
+			if (invitationData.getStatus() != InvitationStatus.PENDING) {
+				throw new CustomException(CustomErrorCode.ALREADY_PROCESSED);
 			}
 			invitationData.setStatus(newStatus);
 			saveInvitationData(key, invitationData);

--- a/src/backend/main-server/main/src/main/java/com/kickzo/main/service/KafkaProducerService.java
+++ b/src/backend/main-server/main/src/main/java/com/kickzo/main/service/KafkaProducerService.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kickzo.main.dto.event.NewUserJoinEvent;
-import com.kickzo.main.dto.event.PlaylistItem;
+import com.kickzo.main.dto.data.PlaylistItem;
 import com.kickzo.main.dto.event.PlaylistUpdateEvent;
 import com.kickzo.main.dto.event.RoleChangeEvent;
 import com.kickzo.main.dto.event.RoomEvent;
@@ -26,52 +26,49 @@ public class KafkaProducerService {
 
 	private final KafkaTemplate<String, String> kafkaTemplate;
 	private final ObjectMapper objectMapper;
+
+	// Topics
 	private static final String TOPIC_ROOM = "room";
 	private static final String TOPIC_PLAYLIST = "playlist";
+	private static final String TOPIC_INVITATION = "invitation";
 
-	public void sendRoomUpdateMessage(Object eventData) {
-		try {
-			RoomEvent roomEvent = new RoomEvent("room-update", eventData);
-			String message = objectMapper.writeValueAsString(roomEvent);
-			kafkaTemplate.send(TOPIC_ROOM, message);
-			log.info("Kafka Room Update Event Sent: {}", message);
-		} catch (JsonProcessingException e) {
-			throw new CustomException(CustomErrorCode.JSON_PROCESSING_ERROR);
-		}
+	// Event Types
+	private static final String EVENT_TYPE_ROOM_UPDATE = "room-update";
+	private static final String EVENT_TYPE_ROLE_CHANGE = "role-change";
+	private static final String EVENT_TYPE_USER_LIST = "user-list";
+	private static final String EVENT_TYPE_PLAYLIST_UPDATE = "playlist-update";
+
+	public void sendRoomUpdateMessage(Object event) {
+		sendEvent(TOPIC_ROOM, EVENT_TYPE_ROOM_UPDATE, event);
 	}
 
 	public void sendRoleChangeEvent(Long roomId, Long targetUserId, int newRole) {
 		RoleChangeEvent event = new RoleChangeEvent(roomId, targetUserId, newRole);
-		RoomEvent roomEvent = new RoomEvent("role-change", event);
-		try {
-			String message = objectMapper.writeValueAsString(roomEvent);
-			kafkaTemplate.send(TOPIC_ROOM, message);
-			log.info("Kafka Role Change Event Sent: {}", message);
-		} catch (JsonProcessingException e) {
-			throw new CustomException(CustomErrorCode.JSON_PROCESSING_ERROR);
-		}
+		sendEvent(TOPIC_ROOM, EVENT_TYPE_ROLE_CHANGE, event);
 	}
 
 	public void sendRoomUserList(Long roomId, List<UserListDto> userList) {
 		NewUserJoinEvent event = new NewUserJoinEvent(roomId, userList);
-		RoomEvent roomEvent = new RoomEvent("user-list", event);
-		try {
-			String message = objectMapper.writeValueAsString(roomEvent);
-			kafkaTemplate.send(TOPIC_ROOM, message);
-			log.info("Kafka New User join UserList Sent: {}", message);
-		} catch (JsonProcessingException e) {
-			throw new CustomException(CustomErrorCode.JSON_PROCESSING_ERROR);
-		}
+		sendEvent(TOPIC_ROOM, EVENT_TYPE_USER_LIST, event);
 	}
 
 	public void sendPlaylistUpdate(Long roomId, List<PlaylistItem> playlistJson) {
 		PlaylistUpdateEvent event = new PlaylistUpdateEvent(roomId, playlistJson);
-		// Kafka 메시지 발행
+		sendEvent(TOPIC_PLAYLIST, EVENT_TYPE_PLAYLIST_UPDATE, event);
+	}
+
+	public void sendRoomInvitation(String invitationData) {
+		kafkaTemplate.send(TOPIC_INVITATION, invitationData);
+	}
+
+	private void sendEvent(String topic, String eventType, Object eventData) {
 		try {
-			String message = objectMapper.writeValueAsString(event);
-			kafkaTemplate.send(TOPIC_PLAYLIST, message);
-			log.info("Kafka Playlist Change Event Sent: {}", message);
+			RoomEvent roomEvent = new RoomEvent(eventType, eventData);
+			String message = objectMapper.writeValueAsString(roomEvent);
+			kafkaTemplate.send(topic, message);
+			log.info("Kafka Event Sent [{}]: {}", eventType, message);
 		} catch (JsonProcessingException e) {
+			log.error("Failed to process JSON for event [{}]: {}", eventType, e.getMessage(), e);
 			throw new CustomException(CustomErrorCode.JSON_PROCESSING_ERROR);
 		}
 	}

--- a/src/backend/main-server/main/src/main/java/com/kickzo/main/service/MainPageService.java
+++ b/src/backend/main-server/main/src/main/java/com/kickzo/main/service/MainPageService.java
@@ -1,6 +1,7 @@
 package com.kickzo.main.service;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -10,15 +11,14 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kickzo.main.dto.data.PlaylistItem;
 import com.kickzo.main.dto.request.CreateRoomRequestDto;
 import com.kickzo.main.dto.response.CreateRoomResponseDto;
 import com.kickzo.main.dto.response.RoomResponseDto;
 import com.kickzo.main.entity.Room;
 import com.kickzo.main.entity.RoomUser;
 import com.kickzo.main.entity.RoomUserId;
+import com.kickzo.main.entity.Playlist;
 import com.kickzo.main.exception.CustomErrorCode;
 import com.kickzo.main.exception.CustomException;
 import com.kickzo.main.repository.RoomRepository;
@@ -40,8 +40,6 @@ public class MainPageService {
 
 	private static final int MAX_ROOMS_PER_USER = 5;
 	private static final int ROLE_CREATOR = 0;
-
-	static final ObjectMapper objectMapper = new ObjectMapper();
 
 	// 메인 페이지 방 list 제공
 	@Transactional(readOnly = true)
@@ -83,28 +81,20 @@ public class MainPageService {
 	 * 4. getCreatorProfileImage : 생성자의 profileImageUrl 받아오기
 	 */
 
-	private String extractPlaylistUrl(String orderJson) {
-		if (orderJson == null || orderJson.isBlank()) {
-			return null;
-		}
-		try {
-			JsonNode orderArray = objectMapper.readTree(orderJson);
-			for (JsonNode node : orderArray) {
-				if (node.has("order") && node.get("order").asInt() == 0 && node.has("url")) {
-					return node.get("url").asText();
-				}
-			}
-		} catch (JsonProcessingException e) {
-			throw new CustomException(CustomErrorCode.JSON_PROCESSING_ERROR);
-		}
-		return null; // order == 0인 항목이 없는 경우
+	private String extractPlaylistUrl(List<PlaylistItem> playlistItems) {
+		return playlistItems.stream()
+			.filter(item -> item.getOrder() == 0)
+			.map(PlaylistItem::getUrl)
+			.findFirst()
+			.orElse(null);
 	}
 
 	private RoomResponseDto convertToDto(Room room) {
+		List<PlaylistItem> playlistItems = Optional.ofNullable(room.getPlaylist())
+			.map(Playlist::getOrderAsList)  // JSON → List 변환
+			.orElse(Collections.emptyList());
 
-		String playlistUrl = Optional.ofNullable(room.getPlaylist())
-			.map(playlist -> extractPlaylistUrl(playlist.getOrder()))
-			.orElse(null);
+		String playlistUrl = extractPlaylistUrl(playlistItems);
 
 		return RoomResponseDto.builder()
 			.roomId(room.getId())
@@ -119,8 +109,7 @@ public class MainPageService {
 	}
 
 	private String getCreatorProfileImage(String creator) {
-		return Optional.ofNullable(userRepository.findProfileImageUrlByNickname(creator))
-			.orElse("default-profile-image-url"); // 기본 이미지 설정
+		return userRepository.findProfileImageUrlByNickname(creator);
 	}
 
 	/**

--- a/src/backend/main-server/main/src/main/java/com/kickzo/main/service/PlaylistService.java
+++ b/src/backend/main-server/main/src/main/java/com/kickzo/main/service/PlaylistService.java
@@ -5,13 +5,8 @@ import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kickzo.main.dto.data.PlaylistItem;
 import com.kickzo.main.entity.Playlist;
-import com.kickzo.main.exception.CustomErrorCode;
-import com.kickzo.main.exception.CustomException;
 import com.kickzo.main.repository.PlaylistRepository;
 
 import jakarta.transaction.Transactional;
@@ -25,43 +20,32 @@ public class PlaylistService {
 
 	private final PlaylistRepository playlistRepository;
 	private final KafkaProducerService kafkaProducerService;
-	private final ObjectMapper objectMapper;
 
 	@Transactional
-	public void savePlaylist(Long roomId, String playlistJson) {
-		List<PlaylistItem> playlistItems = parsePlaylistJson(playlistJson);
-		updateOrCreatePlaylist(roomId, playlistJson);
+	public void savePlaylist(Long roomId, List<PlaylistItem> playlistItems) {
+		updateOrCreatePlaylist(roomId, playlistItems);
 		kafkaProducerService.sendPlaylistUpdate(roomId, playlistItems);
 	}
 
-	private List<PlaylistItem> parsePlaylistJson(String playlistJson) {
-		try {
-			return objectMapper.readValue(playlistJson, new TypeReference<>() {
-			});
-		} catch (JsonProcessingException e) {
-			log.error("Failed to parse playlist JSON: {}", playlistJson, e);
-			throw new CustomException(CustomErrorCode.JSON_PROCESSING_ERROR);
-		}
-	}
-
-	private void updateOrCreatePlaylist(Long roomId, String playlistJson) {
+	private void updateOrCreatePlaylist(Long roomId, List<PlaylistItem> playlistItems) {
 		Optional<Playlist> existingPlaylist = playlistRepository.findByRoomId(roomId);
 
 		if (existingPlaylist.isPresent()) {
-			updateExistingPlaylist(existingPlaylist.get(), playlistJson);
+			updateExistingPlaylist(existingPlaylist.get(), playlistItems);
 		} else {
-			createNewPlaylist(roomId, playlistJson);
+			createNewPlaylist(roomId, playlistItems);
 		}
 	}
 
-	private void updateExistingPlaylist(Playlist playlist, String playlistJson) {
-		playlist.setOrder(playlistJson);
+	private void updateExistingPlaylist(Playlist playlist, List<PlaylistItem> playlistItems) {
+		playlist.setOrderFromList(playlistItems);
 	}
 
-	private void createNewPlaylist(Long roomId, String playlistJson) {
+	private void createNewPlaylist(Long roomId, List<PlaylistItem> playlistItems) {
+
 		Playlist newPlaylist = new Playlist();
 		newPlaylist.setRoomId(roomId);
-		newPlaylist.setOrder(playlistJson);
+		newPlaylist.setOrderFromList(playlistItems);
 		playlistRepository.save(newPlaylist);
 	}
 }

--- a/src/backend/main-server/main/src/main/java/com/kickzo/main/service/PlaylistService.java
+++ b/src/backend/main-server/main/src/main/java/com/kickzo/main/service/PlaylistService.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.kickzo.main.dto.event.PlaylistItem;
+import com.kickzo.main.dto.data.PlaylistItem;
 import com.kickzo.main.entity.Playlist;
 import com.kickzo.main.exception.CustomErrorCode;
 import com.kickzo.main.exception.CustomException;

--- a/src/backend/main-server/main/src/main/java/com/kickzo/main/service/RoomService.java
+++ b/src/backend/main-server/main/src/main/java/com/kickzo/main/service/RoomService.java
@@ -1,9 +1,7 @@
 package com.kickzo.main.service;
 
-import static com.kickzo.main.service.MainPageService.*;
-
 import java.time.LocalDateTime;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -11,8 +9,6 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.kickzo.main.dto.data.PlaylistItem;
 import com.kickzo.main.dto.event.RoomUpdateEvent;
 import com.kickzo.main.dto.request.RoomUpdateRequestDto;
@@ -23,6 +19,7 @@ import com.kickzo.main.dto.response.UserListDto;
 import com.kickzo.main.entity.Room;
 import com.kickzo.main.entity.RoomUser;
 import com.kickzo.main.entity.RoomUserId;
+import com.kickzo.main.entity.Playlist;
 import com.kickzo.main.exception.CustomErrorCode;
 import com.kickzo.main.exception.CustomException;
 import com.kickzo.main.repository.PlaylistRepository;
@@ -169,16 +166,9 @@ public class RoomService {
 	}
 
 	private List<PlaylistItem> fetchPlaylist(Long roomId) {
-		String playlistJson = playlistRepository.findOrderById(roomId);
-		if (playlistJson == null || playlistJson.isBlank()) {
-			return new ArrayList<>();
-		}
-
-		try {
-			return objectMapper.readValue(playlistJson, new TypeReference<>() {});
-		} catch (JsonProcessingException e) {
-			throw new CustomException(CustomErrorCode.JSON_PROCESSING_ERROR);
-		}
+		return playlistRepository.findByRoomId(roomId)
+			.map(Playlist::getOrderAsList)  // JSON → List 변환
+			.orElse(Collections.emptyList());  // Playlist가 없으면 빈 리스트 반환
 	}
 
 	private Long getRoomId(String roomCode) {

--- a/src/backend/main-server/main/src/main/java/com/kickzo/main/service/RoomService.java
+++ b/src/backend/main-server/main/src/main/java/com/kickzo/main/service/RoomService.java
@@ -13,7 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.kickzo.main.dto.event.PlaylistItem;
+import com.kickzo.main.dto.data.PlaylistItem;
 import com.kickzo.main.dto.event.RoomUpdateEvent;
 import com.kickzo.main.dto.request.RoomUpdateRequestDto;
 import com.kickzo.main.dto.response.RoomDetailsDto;
@@ -186,15 +186,14 @@ public class RoomService {
 			.orElseThrow(() -> new CustomException(CustomErrorCode.ROOM_NOT_FOUND));
 	}
 
-	private String getCreatorProfileImage(String creator) {
-		return Optional.ofNullable(userRepository.findProfileImageUrlByNickname(creator))
-			.orElse("default-profile-image-url"); // 기본 이미지 설정
+	private String getCreatorProfileImage(String creatorNickname) {
+		return userRepository.findProfileImageUrlByNickname(creatorNickname);
 	}
 
 	private String getUserProfileImage(Long userId) {
-		return Optional.ofNullable(userRepository.findProfileImageUrlById(userId))
-			.orElse("default-profile-image-url"); // 기본 이미지 설정
+		return userRepository.findProfileImageUrlById(userId);
 	}
+
 
 	private void saveUserCount(Long roomId){
 		Room room = roomRepository.findById(roomId)


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [x] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [x] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명

### 🔗 관련 이슈

<!-- 이슈를 해결했다면 아래에 이슈번호를 숫자로 바꿔주세요. 예) closed #42
  이슈 번호를 작성하면 자동으로 이슈가 닫힙니다. -->

**해결한 이슈**: closed #142 

### 📝 작업 내용

<!-- 작업 내용에 대한 설명을 적어주세요. -->
1. main page와 room의 controller endpoint 수정 (api/rooms)
   - /all : 전체 방 제공
   - /me : 내가 소속한 방 목록 제공
2. playlist 입력 받을 때 String에서 List로 변경
3. profileImageUrl 없을 시 null 제공으로 변경
4. 방 초대와 관련된 invitation controller 추가 (api/rooms)
   - /invitations : 초대 보내기
   - /invitations/accept : 초대 수락
   - /invitations/reject : 초대 거절
   - 모든 요청은 RoomInviteRequestDto(senderId, receiverId, roomId, roomCode)를 body로 받음
5. 방 초대 기능
   - 방 초대는 방에 소속한 사람만 할 수 있음
   - 초대 전송 시 상태는 pending으로 Kafka와 Redis에 보냄 (Redis TTL 7일)
   - 초대 전송 시 초대하려는 유저가 해당 방에 이미 소속 중인지 DB 확인 작업 진행
   - Redis에 아직 초대 정보가 있는 경우(pending, rejected) 초대(/invitations)는 거부됨
   - 초대 상태가 ACCEPTED인 경우는 /invitations/reject 불가능
   - 초대 상태가 REJECTED인 경우에는 /invitations/accept 불가능

### 📸 스크린샷(optional)

<!-- 이해에 도움이 될만한 스크린샷을 첨부해주세요. -->
#### 변경한 playlist 입력 방식
![스크린샷 2025-02-13 103422](https://github.com/user-attachments/assets/5eaf9427-369e-4b1f-b6c5-4aee4f60175a)

#### 방 초대 보내기 (/invitations)
<img src="https://github.com/user-attachments/assets/0f47a2aa-9395-491c-93a9-d7ce50ffd4eb" width="400">
<img src="https://github.com/user-attachments/assets/ed95fcf1-25cc-4b24-aa7e-e01825a00b9b" width="300">
<img src="https://github.com/user-attachments/assets/0411eae2-79d4-4286-b388-bfa61c04791c" width="800">

#### 같은 초대 내용을 다시 보낼 경우 (/invitations)
<img src="https://github.com/user-attachments/assets/c7d17c14-7290-467d-8833-9ee4a9d7dc67" width="400">

#### 이미 방에 소속되어 있는 사용자를 초대할 경우 (/invitations)
<img src="https://github.com/user-attachments/assets/59ab1f4e-9c40-4190-93dc-ef2ccbbc7ac8" width="400">

#### 내가 받은 초대 내용이 아닌 경우 (/invitations/accept, /invitations/reject)
<img src="https://github.com/user-attachments/assets/9cdac279-0732-4fdc-a887-c98200097e46" width="400">

#### 초대 요청을 수락할 경우 : DB에 저장 + Redis에 상태 변경 (/invitations/accept)
<img src="https://github.com/user-attachments/assets/1d6de3f6-40b7-4be9-b9a0-ea9c96bceac9" width="300">

#### 초대 요청을 거절할 경우 : DB에 저장 + Redis에 상태 변경 (/invitations/reject)
<img src="https://github.com/user-attachments/assets/29200a80-f174-453e-acfe-d39174f249bd" width="300">



## Trouble Shooting
1. Redis 데이터 역직렬화 문제
2. Redis에 저장된 데이터에 `@class` 필드가 포함되고 Boolean 필드(isRead)가 read로 직렬화
3. Kafka 메시지 직렬화 실패
   - Kafka 메시지를 `objectMapper.writeValueAsString()`으로 JSON 변환할 때, Enum 값 직렬화에서 오류가 발생