### PR TITLE
[iOS] BUG: 유저 목록 bottom sheet 문제 해결 #169

### DIFF
--- a/src/iOS/KickTube/KickTube/Features/Home/Reactor/UserListReactor.swift
+++ b/src/iOS/KickTube/KickTube/Features/Home/Reactor/UserListReactor.swift
@@ -22,7 +22,7 @@ final class UserListReactor: Reactor {
         case userOverview(_ idx: IndexPath)
     }
     
-    struct State{
+    struct State {
         var userList: [KickRoomUserViewModel]
         var searchUserResult: [KickRoomUserViewModel] = []
         var selectedCell: (id: Int, role: UserRole)?
@@ -65,8 +65,14 @@ final class UserListReactor: Reactor {
                 
                 newState.searchUserResult = result
             }
+            newState.selectedCell = nil
         case .userOverview(let idx):
-            let user = newState.userList[idx.row]
+            var user: KickRoomUserViewModel
+            if newState.searchUserResult.count == 0 {
+                user = newState.searchUserResult[idx.row]
+            } else {
+                user = newState.userList[idx.row]
+            }
             
             newState.selectedCell = (id: user.userID, role: user.role)
         }

--- a/src/iOS/KickTube/KickTube/Features/Home/View/View/UserListView.swift
+++ b/src/iOS/KickTube/KickTube/Features/Home/View/View/UserListView.swift
@@ -45,7 +45,6 @@ final class UserListView: BaseView<UserListReactor> {
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         userlistCollectionView.rx.itemSelected
-            .distinctUntilChanged()
             .map { Reactor.Action.profileCellTapped(idx: $0) }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)

--- a/src/iOS/KickTube/KickTube/Features/Home/View/View/VoiceChatListView.swift
+++ b/src/iOS/KickTube/KickTube/Features/Home/View/View/VoiceChatListView.swift
@@ -36,6 +36,13 @@ final class VoiceChatListView: BaseView<VoiceChatListReactor> {
     private let entryButton = RoundButton("입장", bgColor: .primary, titleColor: .white, toggleBgColor: .kDarkgray, toggleTitleColor: .white)
     
     
+    // MARK: - initializer
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+    
+    
     // MARK: - configure reactor
 
     override func bindAction(reactor: VoiceChatListReactor) {
@@ -71,6 +78,7 @@ final class VoiceChatListView: BaseView<VoiceChatListReactor> {
         reactor.state
             .map { $0.selectedCell }
             .compactMap { $0 }
+            .subscribe(on: MainScheduler.instance)
             .subscribe(with: self) { owner, value in
                 NotificationCenter.default.post(name: .presentVoiceUserOverview, object: nil, userInfo: ["voiceState": value])
             }
@@ -78,6 +86,7 @@ final class VoiceChatListView: BaseView<VoiceChatListReactor> {
         reactor.state
             .map { $0.myMicState }
             .distinctUntilChanged { _, _ in false }
+            .subscribe(on: MainScheduler.instance)
             .subscribe(with: self) { owner, value in
                 if value {
                     owner.micButton.setImage(.micOn, for: .normal)
@@ -89,6 +98,7 @@ final class VoiceChatListView: BaseView<VoiceChatListReactor> {
         reactor.state
             .map { $0.myHeadsetState }
             .distinctUntilChanged()
+            .subscribe(on: MainScheduler.instance)
             .subscribe(with: self) { owner, value in
                 if value {
                     owner.headsetButton.setImage(.headsetOn, for: .normal)
@@ -100,6 +110,7 @@ final class VoiceChatListView: BaseView<VoiceChatListReactor> {
         reactor.state
             .map { $0.myVoiceChattingState }
             .distinctUntilChanged()
+            .subscribe(on: MainScheduler.instance)
             .subscribe(with: self) { owner, value in
                 if value {
                     owner.entryButton.setTitle("나가기")


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [x] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
- cell을 한 번 선택하고 bottom sheet가 present 된 이후로, 유저 목록을 검색할 때마다 bottom sheet가 present되는 문제를 해결
### 🔗 관련 이슈

<!-- 이슈를 해결했다면 아래에 이슈번호를 숫자로 바꿔주세요. 예) closed #42
  이슈 번호를 작성하면 자동으로 이슈가 닫힙니다. -->

**해결한 이슈**: closed #169

### 📝 작업 내용

<!-- 작업 내용에 대한 설명을 적어주세요. -->
- cell 을 선택하는 action과, 그에 따른 newstate.selectedCell을 구독하는 단방향 흐름에서, newstate의 다른 action을 취해서 새로운 state가 리턴될 때 해당 이벤트 방출을 selectedCell에서도 방출하고 있는 문제 였습니다.
-  https://github.com/sgdevcamp2025/kickzo/pull/144 해당 PR의 Trouble Shooting과 동일한 문제, 해결 방법입니다.

### 📸 스크린샷(optional)

<!-- 이해에 도움이 될만한 스크린샷을 첨부해주세요. -->

![Simulator Screen Recording - iPhone SE (3rd generation) - 2025-02-13 at 19 18 28](https://github.com/user-attachments/assets/8e123255-4d8c-4700-9ec0-040c970aa3f6)

