### PR TITLE
[BE] auth, user 서버 swagger 추가 및 버저닝 적용 #183

### DIFF
--- a/src/backend/auth-server/nest-cli.json
+++ b/src/backend/auth-server/nest-cli.json
@@ -3,6 +3,7 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
-    "deleteOutDir": true
+    "deleteOutDir": true,
+    "plugins": ["@nestjs/swagger"]
   }
 }

--- a/src/backend/auth-server/package.json
+++ b/src/backend/auth-server/package.json
@@ -28,6 +28,7 @@
     "@nestjs/mapped-types": "*",
     "@nestjs/microservices": "^11.0.6",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/swagger": "^11.0.3",
     "@nestjs/typeorm": "^11.0.0",
     "bcryptjs": "^2.4.3",
     "class-transformer": "^0.5.1",

--- a/src/backend/auth-server/pnpm-lock.yaml
+++ b/src/backend/auth-server/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@nestjs/platform-express':
         specifier: ^11.0.1
         version: 11.0.6(@nestjs/common@11.0.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@11.0.6)
+      '@nestjs/swagger':
+        specifier: ^11.0.3
+        version: 11.0.3(@nestjs/common@11.0.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@11.0.6)(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)
       '@nestjs/typeorm':
         specifier: ^11.0.0
         version: 11.0.0(@nestjs/common@11.0.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@11.0.6)(reflect-metadata@0.2.2)(rxjs@7.8.1)(typeorm@0.3.20(ioredis@5.4.2)(mysql2@3.12.0)(ts-node@10.9.2(@swc/core@1.10.12)(@types/node@22.12.0)(typescript@5.7.3)))
@@ -617,6 +620,9 @@ packages:
     resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
     engines: {node: '>=8'}
 
+  '@microsoft/tsdoc@0.15.0':
+    resolution: {integrity: sha512-HZpPoABogPvjeJOdzCOSJsXeL/SMCBgBZMVC3X3d7YYp2gf31MfxhUoYUNwf1ERPJOnQc0wkFn9trqI6ZEdZuA==}
+
   '@napi-rs/nice-android-arm-eabi@1.0.1':
     resolution: {integrity: sha512-5qpvOu5IGwDo7MEKVqqyAxF90I6aLj4n07OzpARdgDRfz8UbBztTByBp0RC59r3J1Ij8uzYi6jI7r5Lws7nn6w==}
     engines: {node: '>= 10'}
@@ -832,6 +838,23 @@ packages:
     peerDependencies:
       typescript: '>=4.8.2'
 
+  '@nestjs/swagger@11.0.3':
+    resolution: {integrity: sha512-oyrhrAzVJz1wYefIYDb6Y0f1VYb8BtYxEI7Ex0ApoUsfGZThyhW9elYANcfBXVaTmICrU8lCESF2ygF6s0ThIw==}
+    peerDependencies:
+      '@fastify/static': ^8.0.0
+      '@nestjs/common': ^11.0.1
+      '@nestjs/core': ^11.0.1
+      class-transformer: '*'
+      class-validator: '*'
+      reflect-metadata: ^0.1.12 || ^0.2.0
+    peerDependenciesMeta:
+      '@fastify/static':
+        optional: true
+      class-transformer:
+        optional: true
+      class-validator:
+        optional: true
+
   '@nestjs/testing@11.0.6':
     resolution: {integrity: sha512-RZDWdnOncOQ1vT3630VlRzKee2P21ZJoF1+NAY+nzYUuYuYAaBdjrTZQGwymmiZQcrM+TQaViSjSPUmcJXdKyA==}
     peerDependencies:
@@ -878,6 +901,9 @@ packages:
   '@pkgr/core@0.1.1':
     resolution: {integrity: sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@scarf/scarf@1.4.0':
+    resolution: {integrity: sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==}
 
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
@@ -3378,6 +3404,9 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  swagger-ui-dist@5.18.2:
+    resolution: {integrity: sha512-J+y4mCw/zXh1FOj5wGJvnAajq6XgHOyywsa9yITmwxIlJbMqITq3gYRZHaeqLVH/eV/HOPphE6NjF+nbSNC5Zw==}
+
   symbol-observable@4.0.0:
     resolution: {integrity: sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==}
     engines: {node: '>=0.10'}
@@ -4422,6 +4451,8 @@ snapshots:
 
   '@lukeed/csprng@1.1.0': {}
 
+  '@microsoft/tsdoc@0.15.0': {}
+
   '@napi-rs/nice-android-arm-eabi@1.0.1':
     optional: true
 
@@ -4602,6 +4633,21 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
+  '@nestjs/swagger@11.0.3(@nestjs/common@11.0.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@11.0.6)(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)':
+    dependencies:
+      '@microsoft/tsdoc': 0.15.0
+      '@nestjs/common': 11.0.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
+      '@nestjs/core': 11.0.6(@nestjs/common@11.0.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/microservices@11.0.6)(@nestjs/platform-express@11.0.6)(reflect-metadata@0.2.2)(rxjs@7.8.1)
+      '@nestjs/mapped-types': 2.1.0(@nestjs/common@11.0.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)
+      js-yaml: 4.1.0
+      lodash: 4.17.21
+      path-to-regexp: 8.2.0
+      reflect-metadata: 0.2.2
+      swagger-ui-dist: 5.18.2
+    optionalDependencies:
+      class-transformer: 0.5.1
+      class-validator: 0.14.1
+
   '@nestjs/testing@11.0.6(@nestjs/common@11.0.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@11.0.6)(@nestjs/microservices@11.0.6)(@nestjs/platform-express@11.0.6)':
     dependencies:
       '@nestjs/common': 11.0.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
@@ -4639,6 +4685,8 @@ snapshots:
     optional: true
 
   '@pkgr/core@0.1.1': {}
+
+  '@scarf/scarf@1.4.0': {}
 
   '@sec-ant/readable-stream@0.4.1': {}
 
@@ -7399,6 +7447,10 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  swagger-ui-dist@5.18.2:
+    dependencies:
+      '@scarf/scarf': 1.4.0
 
   symbol-observable@4.0.0: {}
 

--- a/src/backend/auth-server/src/auth/auth.controller.ts
+++ b/src/backend/auth-server/src/auth/auth.controller.ts
@@ -8,6 +8,7 @@ import {
   UnauthorizedException,
   UsePipes,
   ValidationPipe,
+  VERSION_NEUTRAL,
 } from "@nestjs/common";
 import { AuthService } from "./auth.service";
 import { Authorization } from "./decorator/authorization.decorator";
@@ -23,7 +24,7 @@ import {
 import { DeviceType } from "./enum/device-type.enum";
 import { Request, Response } from "express";
 
-@Controller("api/auth")
+@Controller({ path: "api/auth", version: VERSION_NEUTRAL })
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
 

--- a/src/backend/auth-server/src/auth/auth.controller.ts
+++ b/src/backend/auth-server/src/auth/auth.controller.ts
@@ -23,12 +23,15 @@ import {
 } from "./constants/constants";
 import { DeviceType } from "./enum/device-type.enum";
 import { Request, Response } from "express";
+import { ApiBasicAuth, ApiBearerAuth, ApiOperation } from "@nestjs/swagger";
 
 @Controller({ path: "api/auth", version: VERSION_NEUTRAL })
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
   @Post("login")
+  @ApiBasicAuth()
+  @ApiOperation({ summary: "로그인" })
   @UsePipes(ValidationPipe)
   async loginUser(
     @Authorization() token: string,
@@ -56,6 +59,8 @@ export class AuthController {
 
   @Post("logout")
   @HttpCode(200)
+  @ApiBearerAuth("access")
+  @ApiOperation({ summary: "로그아웃" })
   async logout(
     @Authorization() accessToken: string,
     @Res({ passthrough: true }) res: Response,
@@ -71,6 +76,9 @@ export class AuthController {
   }
 
   @Post("token/refresh")
+  @HttpCode(200)
+  @ApiBearerAuth("refresh")
+  @ApiOperation({ summary: "토큰 갱신" })
   async rotateAccessToken(
     @Req() req: Request,
     @Res({ passthrough: true }) res: Response,
@@ -122,6 +130,8 @@ export class AuthController {
 
   @Post("token/verify")
   @HttpCode(200)
+  @ApiBearerAuth("access")
+  @ApiOperation({ summary: "토큰 검증" })
   async verifyAccessToken(@Authorization() accessToken: string) {
     if (!accessToken) {
       throw new UnauthorizedException(MESSAGES.INVALID_TOKEN);

--- a/src/backend/auth-server/src/auth/dto/device-type.dto.ts
+++ b/src/backend/auth-server/src/auth/dto/device-type.dto.ts
@@ -1,10 +1,15 @@
 import { IsEnum, IsNotEmpty } from "class-validator";
 import { DeviceType } from "../enum/device-type.enum";
 import { MESSAGES } from "../constants/constants";
+import { ApiProperty } from "@nestjs/swagger";
 export class DeviceTypeDto {
   @IsNotEmpty({ message: MESSAGES.REQUIRED_DEVICE })
   @IsEnum(DeviceType, {
     message: MESSAGES.INVALID_DEVICE,
+  })
+  @ApiProperty({
+    description: "디바이스 타입",
+    example: "mobile",
   })
   device: DeviceType;
 }

--- a/src/backend/auth-server/src/main.ts
+++ b/src/backend/auth-server/src/main.ts
@@ -2,10 +2,15 @@ import { NestFactory } from "@nestjs/core";
 import { AppModule } from "./app.module";
 import { MicroserviceOptions, Transport } from "@nestjs/microservices";
 import * as cookieParser from "cookie-parser";
+import { VersioningType } from "@nestjs/common";
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.use(cookieParser());
+  app.enableVersioning({
+    type: VersioningType.HEADER,
+    header: "version",
+  });
   app.connectMicroservice<MicroserviceOptions>({
     transport: Transport.TCP,
     options: {

--- a/src/backend/auth-server/src/main.ts
+++ b/src/backend/auth-server/src/main.ts
@@ -3,9 +3,39 @@ import { AppModule } from "./app.module";
 import { MicroserviceOptions, Transport } from "@nestjs/microservices";
 import * as cookieParser from "cookie-parser";
 import { VersioningType } from "@nestjs/common";
+import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  const config = new DocumentBuilder()
+    .setTitle("Kicktube Auth API")
+    .setDescription("Kicktube Auth API 설명입니다.")
+    .setVersion("1.0")
+    .addBasicAuth()
+    .addBearerAuth(
+      {
+        type: "http",
+        scheme: "bearer",
+        bearerFormat: "JWT",
+      },
+      "access",
+    )
+    .addBearerAuth(
+      {
+        type: "http",
+        scheme: "bearer",
+        bearerFormat: "JWT",
+      },
+      "refresh",
+    )
+    .build();
+  const document = SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup("api/auth/doc", app, document, {
+    swaggerOptions: {
+      persistAuthorization: true,
+    },
+  });
+
   app.use(cookieParser());
   app.enableVersioning({
     type: VersioningType.HEADER,

--- a/src/backend/user-server/nest-cli.json
+++ b/src/backend/user-server/nest-cli.json
@@ -3,6 +3,7 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
-    "deleteOutDir": true
+    "deleteOutDir": true,
+    "plugins": ["@nestjs/swagger"]
   }
 }

--- a/src/backend/user-server/package.json
+++ b/src/backend/user-server/package.json
@@ -28,6 +28,7 @@
     "@nestjs/mapped-types": "^2.1.0",
     "@nestjs/microservices": "^11.0.6",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/swagger": "^11.0.3",
     "@nestjs/typeorm": "^11.0.0",
     "bcryptjs": "^2.4.3",
     "class-transformer": "^0.5.1",

--- a/src/backend/user-server/pnpm-lock.yaml
+++ b/src/backend/user-server/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@nestjs/platform-express':
         specifier: ^11.0.1
         version: 11.0.6(@nestjs/common@11.0.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@11.0.6)
+      '@nestjs/swagger':
+        specifier: ^11.0.3
+        version: 11.0.3(@nestjs/common@11.0.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@11.0.6)(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)
       '@nestjs/typeorm':
         specifier: ^11.0.0
         version: 11.0.0(@nestjs/common@11.0.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@11.0.6)(reflect-metadata@0.2.2)(rxjs@7.8.1)(typeorm@0.3.20(ioredis@5.4.2)(mysql2@3.12.0)(ts-node@10.9.2(@swc/core@1.10.12)(@types/node@22.12.0)(typescript@5.7.3)))
@@ -614,6 +617,9 @@ packages:
     resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
     engines: {node: '>=8'}
 
+  '@microsoft/tsdoc@0.15.0':
+    resolution: {integrity: sha512-HZpPoABogPvjeJOdzCOSJsXeL/SMCBgBZMVC3X3d7YYp2gf31MfxhUoYUNwf1ERPJOnQc0wkFn9trqI6ZEdZuA==}
+
   '@napi-rs/nice-android-arm-eabi@1.0.1':
     resolution: {integrity: sha512-5qpvOu5IGwDo7MEKVqqyAxF90I6aLj4n07OzpARdgDRfz8UbBztTByBp0RC59r3J1Ij8uzYi6jI7r5Lws7nn6w==}
     engines: {node: '>= 10'}
@@ -829,6 +835,23 @@ packages:
     peerDependencies:
       typescript: '>=4.8.2'
 
+  '@nestjs/swagger@11.0.3':
+    resolution: {integrity: sha512-oyrhrAzVJz1wYefIYDb6Y0f1VYb8BtYxEI7Ex0ApoUsfGZThyhW9elYANcfBXVaTmICrU8lCESF2ygF6s0ThIw==}
+    peerDependencies:
+      '@fastify/static': ^8.0.0
+      '@nestjs/common': ^11.0.1
+      '@nestjs/core': ^11.0.1
+      class-transformer: '*'
+      class-validator: '*'
+      reflect-metadata: ^0.1.12 || ^0.2.0
+    peerDependenciesMeta:
+      '@fastify/static':
+        optional: true
+      class-transformer:
+        optional: true
+      class-validator:
+        optional: true
+
   '@nestjs/testing@11.0.6':
     resolution: {integrity: sha512-RZDWdnOncOQ1vT3630VlRzKee2P21ZJoF1+NAY+nzYUuYuYAaBdjrTZQGwymmiZQcrM+TQaViSjSPUmcJXdKyA==}
     peerDependencies:
@@ -875,6 +898,9 @@ packages:
   '@pkgr/core@0.1.1':
     resolution: {integrity: sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@scarf/scarf@1.4.0':
+    resolution: {integrity: sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==}
 
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
@@ -3359,6 +3385,9 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  swagger-ui-dist@5.18.2:
+    resolution: {integrity: sha512-J+y4mCw/zXh1FOj5wGJvnAajq6XgHOyywsa9yITmwxIlJbMqITq3gYRZHaeqLVH/eV/HOPphE6NjF+nbSNC5Zw==}
+
   symbol-observable@4.0.0:
     resolution: {integrity: sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==}
     engines: {node: '>=0.10'}
@@ -4408,6 +4437,8 @@ snapshots:
 
   '@lukeed/csprng@1.1.0': {}
 
+  '@microsoft/tsdoc@0.15.0': {}
+
   '@napi-rs/nice-android-arm-eabi@1.0.1':
     optional: true
 
@@ -4588,6 +4619,21 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
+  '@nestjs/swagger@11.0.3(@nestjs/common@11.0.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@11.0.6)(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)':
+    dependencies:
+      '@microsoft/tsdoc': 0.15.0
+      '@nestjs/common': 11.0.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
+      '@nestjs/core': 11.0.6(@nestjs/common@11.0.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/microservices@11.0.6)(@nestjs/platform-express@11.0.6)(reflect-metadata@0.2.2)(rxjs@7.8.1)
+      '@nestjs/mapped-types': 2.1.0(@nestjs/common@11.0.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)
+      js-yaml: 4.1.0
+      lodash: 4.17.21
+      path-to-regexp: 8.2.0
+      reflect-metadata: 0.2.2
+      swagger-ui-dist: 5.18.2
+    optionalDependencies:
+      class-transformer: 0.5.1
+      class-validator: 0.14.1
+
   '@nestjs/testing@11.0.6(@nestjs/common@11.0.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@11.0.6)(@nestjs/microservices@11.0.6)(@nestjs/platform-express@11.0.6)':
     dependencies:
       '@nestjs/common': 11.0.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
@@ -4625,6 +4671,8 @@ snapshots:
     optional: true
 
   '@pkgr/core@0.1.1': {}
+
+  '@scarf/scarf@1.4.0': {}
 
   '@sec-ant/readable-stream@0.4.1': {}
 
@@ -7372,6 +7420,10 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  swagger-ui-dist@5.18.2:
+    dependencies:
+      '@scarf/scarf': 1.4.0
 
   symbol-observable@4.0.0: {}
 

--- a/src/backend/user-server/src/main.ts
+++ b/src/backend/user-server/src/main.ts
@@ -2,9 +2,22 @@ import { NestFactory } from "@nestjs/core";
 import { AppModule } from "./app.module";
 import { MicroserviceOptions, Transport } from "@nestjs/microservices";
 import { VersioningType } from "@nestjs/common";
+import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  const config = new DocumentBuilder()
+    .setTitle("Kicktube User API")
+    .setDescription("Kicktube User API 설명입니다.")
+    .setVersion("1.0")
+    .addBearerAuth()
+    .build();
+  const document = SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup("api/users/doc", app, document, {
+    swaggerOptions: {
+      persistAuthorization: true,
+    },
+  });
   app.enableVersioning({
     type: VersioningType.HEADER,
     header: "version",

--- a/src/backend/user-server/src/main.ts
+++ b/src/backend/user-server/src/main.ts
@@ -1,9 +1,14 @@
 import { NestFactory } from "@nestjs/core";
 import { AppModule } from "./app.module";
 import { MicroserviceOptions, Transport } from "@nestjs/microservices";
+import { VersioningType } from "@nestjs/common";
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.enableVersioning({
+    type: VersioningType.HEADER,
+    header: "version",
+  });
   app.connectMicroservice<MicroserviceOptions>({
     transport: Transport.TCP,
     options: {

--- a/src/backend/user-server/src/user/dto/check-exists.dto.ts
+++ b/src/backend/user-server/src/user/dto/check-exists.dto.ts
@@ -1,6 +1,7 @@
 import { IsEmail, IsString, ValidateIf } from "class-validator";
 import { Transform } from "class-transformer";
 import { IsNickname } from "../decorators/nickname.decorator";
+import { ApiProperty } from "@nestjs/swagger";
 
 interface ICheckExists {
   nickname?: string;
@@ -12,10 +13,18 @@ export class CheckExistsDto {
   @IsString()
   @IsNickname()
   @Transform(({ value }: { value: string }) => value?.trim())
+  @ApiProperty({
+    description: "닉네임(한글, 영어, 숫자 포함 최소 1자 최대 20자)",
+    example: "test",
+  })
   nickname?: string;
 
   @ValidateIf((o: ICheckExists) => !o.nickname)
   @IsEmail()
   @Transform(({ value }: { value: string }) => value?.trim())
+  @ApiProperty({
+    description: "이메일",
+    example: "test@test.com",
+  })
   email?: string;
 }

--- a/src/backend/user-server/src/user/dto/create-user.dto.ts
+++ b/src/backend/user-server/src/user/dto/create-user.dto.ts
@@ -1,19 +1,32 @@
 import { IsEmail, IsNotEmpty, IsString } from "class-validator";
 import { IsNickname } from "../decorators/nickname.decorator";
 import { IsPassword } from "../decorators/password.decorator";
+import { ApiProperty } from "@nestjs/swagger";
 
 export class CreateUserDto {
   @IsEmail()
   @IsNotEmpty()
+  @ApiProperty({
+    description: "이메일",
+    example: "test@test.com",
+  })
   email: string;
 
   @IsString()
   @IsNotEmpty()
   @IsNickname()
+  @ApiProperty({
+    description: "닉네임(한글, 영어, 숫자 포함 최소 1자 최대 20자)",
+    example: "test",
+  })
   nickname: string;
 
   @IsString()
   @IsNotEmpty()
   @IsPassword()
+  @ApiProperty({
+    description: "비밀번호(영어, 숫자, 특수문자 포함 최소 8자 최대 20자)",
+    example: "test1234#",
+  })
   password: string;
 }

--- a/src/backend/user-server/src/user/dto/update-user.dto.ts
+++ b/src/backend/user-server/src/user/dto/update-user.dto.ts
@@ -1,17 +1,26 @@
 import { IsString, IsOptional, Length } from "class-validator";
 import { IsNickname } from "../decorators/nickname.decorator";
 import { LENGTH_LIMIT, MESSAGES } from "../constants/constants";
+import { ApiProperty } from "@nestjs/swagger";
 
 export class UpdateUserDto {
   @IsOptional()
   @IsString()
   @IsNickname()
+  @ApiProperty({
+    description: "닉네임(한글, 영어, 숫자 포함 최소 1자 최대 20자)",
+    example: "test",
+  })
   nickname?: string;
 
   @IsOptional()
   @IsString()
   @Length(LENGTH_LIMIT.STATE_MESSAGE_MIN, LENGTH_LIMIT.STATE_MESSAGE_MAX, {
     message: MESSAGES.STATE_MESSAGE_LENGTH,
+  })
+  @ApiProperty({
+    description: "상태 메시지(최소 0자 최대 100자)",
+    example: "hello world!",
   })
   stateMessage?: string;
 }

--- a/src/backend/user-server/src/user/entity/user.entity.ts
+++ b/src/backend/user-server/src/user/entity/user.entity.ts
@@ -1,3 +1,4 @@
+import { ApiHideProperty } from "@nestjs/swagger";
 import { Exclude, Expose } from "class-transformer";
 import {
   Entity,
@@ -22,6 +23,7 @@ export class User {
 
   @Column({ type: "timestamp", default: () => "CURRENT_TIMESTAMP" })
   @Exclude()
+  @ApiHideProperty()
   nicknameUpdatedAt: Date; // 최근 별명 업데이트 시간
 
   @Column({ type: "int", default: 0 })
@@ -35,14 +37,17 @@ export class User {
 
   @Column({ type: "char", length: 64, select: false })
   @Exclude()
+  @ApiHideProperty()
   salt: string; // 솔트값
 
   @Column({ type: "char", length: 64, select: false }) // select: false -> 쿼리할 때 제외
   @Exclude()
+  @ApiHideProperty()
   password: string; // 해싱된 비밀번호
 
   @Column({ type: "timestamp", default: () => "CURRENT_TIMESTAMP" })
   @Exclude()
+  @ApiHideProperty()
   passwordUpdatedAt: Date; // 비밀번호 변경 시각
 
   @Column({ type: "varchar", length: 100, nullable: true })
@@ -50,14 +55,17 @@ export class User {
 
   @CreateDateColumn({ type: "timestamp" })
   @Exclude()
+  @ApiHideProperty()
   createdAt: Date; // 유저 생성 시각
 
   @UpdateDateColumn({ type: "timestamp" })
   @Exclude()
+  @ApiHideProperty()
   accessedAt: Date; // 마지막 접근 시각
 
   @DeleteDateColumn({ type: "datetime", nullable: true })
   @Exclude()
+  @ApiHideProperty()
   deletedAt: Date; // 탈퇴 시간(soft delete)
 
   getPassword(): string {

--- a/src/backend/user-server/src/user/user.controller.ts
+++ b/src/backend/user-server/src/user/user.controller.ts
@@ -25,6 +25,7 @@ import { CheckExistsDto } from "./dto/check-exists.dto";
 import { UpdateUserDto } from "./dto/update-user.dto";
 import { MESSAGES } from "./constants/constants";
 import { VERSION_NEUTRAL } from "@nestjs/common";
+import { ApiBearerAuth, ApiOperation } from "@nestjs/swagger";
 
 @Controller({ path: "api/users", version: VERSION_NEUTRAL })
 @UseInterceptors(ClassSerializerInterceptor)
@@ -32,12 +33,15 @@ export class UserController {
   constructor(private readonly userService: UserService) {}
 
   @Post("register")
+  @ApiOperation({ summary: "회원가입" })
   @UsePipes(ValidationPipe)
   registerUser(@Body() createUserDto: CreateUserDto) {
     return this.userService.create(createUserDto);
   }
 
   @Delete("unregister")
+  @ApiBearerAuth()
+  @ApiOperation({ summary: "회원탈퇴" })
   async deleteUser(@Req() req: Request) {
     const userId = req.headers["x-user-id"];
     if (!userId) {
@@ -47,6 +51,9 @@ export class UserController {
   }
 
   @Get("exists")
+  @ApiOperation({
+    summary: "닉네임, 이메일 중복 체크(닉네임 또는 이메일 중 하나만 전달)",
+  })
   @UsePipes(new ValidationPipe({ transform: true }))
   async checkExists(@Query() query: CheckExistsDto) {
     if (query.nickname && query.email) {
@@ -62,6 +69,8 @@ export class UserController {
   }
 
   @Get("me")
+  @ApiBearerAuth()
+  @ApiOperation({ summary: "내 정보 조회" })
   async getMyInfo(@Req() req: Request) {
     const id = req.headers["x-user-id"];
     if (!id) {
@@ -71,6 +80,8 @@ export class UserController {
   }
 
   @Patch("me")
+  @ApiBearerAuth()
+  @ApiOperation({ summary: "내 정보 수정" })
   @UsePipes(ValidationPipe)
   async updateProfile(
     @Req() req: Request,
@@ -87,6 +98,7 @@ export class UserController {
   }
 
   @Get()
+  @ApiOperation({ summary: "모든 유저 조회" })
   async findAll(
     @Query("page", new DefaultValuePipe(0), ParseIntPipe) page: number = 0,
     @Query("size", new DefaultValuePipe(10), ParseIntPipe) size: number = 10,
@@ -95,6 +107,7 @@ export class UserController {
   }
 
   @Get(":id")
+  @ApiOperation({ summary: "유저 조회" })
   async getUserById(@Param("id", ParseIntPipe) id: string) {
     return this.userService.getUserById(+id);
   }

--- a/src/backend/user-server/src/user/user.controller.ts
+++ b/src/backend/user-server/src/user/user.controller.ts
@@ -24,7 +24,9 @@ import { UnauthorizedException } from "@nestjs/common";
 import { CheckExistsDto } from "./dto/check-exists.dto";
 import { UpdateUserDto } from "./dto/update-user.dto";
 import { MESSAGES } from "./constants/constants";
-@Controller("api/users")
+import { VERSION_NEUTRAL } from "@nestjs/common";
+
+@Controller({ path: "api/users", version: VERSION_NEUTRAL })
 @UseInterceptors(ClassSerializerInterceptor)
 export class UserController {
   constructor(private readonly userService: UserService) {}


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명

### 🔗 관련 이슈

**해결한 이슈**: closed #183

### 📝 작업 내용

#### version

- 헤더에 version을 받아서 버저닝을 할 수 있도록 처리했습니다. 버전이 없는 경우에는 default로 들어올 수 있게 해뒀습니다.
- 추후에 v2를 만들 경우를 대비해 확장성을 위해 작업해뒀습니다.

```
app.enableVersioning({
    type: VersioningType.HEADER,
    header: "version",
  });
```

#### Swagger

- **인증**: [http://localhost:8000/api/auth/doc](http://localhost:8000/api/auth/doc)
- **유저**: [http://localhost:8000/api/users/doc](http://localhost:8000/api/users/doc)

추가 내용
- 인증은 `Basic`, `access`, `refresh` 각각 넣도록 처리되어 있습니다.
- 스키마에 `dto` 열어보시면 상세설명 적혀 있습니다.
- 새로고침 시에도 유지되게 처리했습니다.(`persistAuthorization: true`)

**[추천]**
**accessToken의 `iat` 숫자를 많이 늘리면 오래도록 사용할 수 있습니다. [https://jwt.io/](https://jwt.io/)에서 변경 가능합니다.** 
**signature에 들어갈 secret key는 `.env`에 있으니 여유있는 토큰을 만들어서 편하게 쓰세요!**

### 📸 스크린샷(optional)
| 이미지 | 설명 |
|--------|------|
| ![image](https://github.com/user-attachments/assets/6e9e2e95-8e2e-4d29-93a1-2b613bdad4e2) | Auth Swagger |
| ![image](https://github.com/user-attachments/assets/7b13df15-a2cd-4f12-a404-cf8c539322f1) | Auth authorizations |
| ![image](https://github.com/user-attachments/assets/22f4ed42-86a1-4181-95ca-9d92dd51d89e) | User Swagger |
| ![image](https://github.com/user-attachments/assets/22ff3a77-3e52-4781-92ab-88651ce7affe) | jwt.io에서 토큰 유효기간 늘리는 방법 |
| ![image](https://github.com/user-attachments/assets/0856108c-c503-4309-917d-18c181a38056) | 스키마 설명 |
